### PR TITLE
Added console.log to examine an error which occurs only in production environment.

### DIFF
--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -52,7 +52,8 @@ const Login = () => {
             }
           });
         } else {
-          window.location.reload();
+          // window.location.reload();
+          console.log('error is: ', error);
         }
       });
   };
@@ -80,7 +81,8 @@ const Login = () => {
             }
           });
         } else {
-          window.location.reload();
+          // window.location.reload();
+          console.log('error is: ', error);
         }
       });
   };

--- a/firebaseAdmin.ts
+++ b/firebaseAdmin.ts
@@ -3,7 +3,9 @@ const serviceAccount = {
   type: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_TYPE,
   project_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PROJECT_ID,
   private_key_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY_ID,
-  private_key: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY,
+  private_key: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY
+    ? process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY.replace(/\\n/g, '\n')
+    : undefined,
   client_email: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_EMAIL,
   client_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_ID,
   auth_uri: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_AUTH_URI,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "polygon-hr",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://workstats.dev",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next build && next start",
+    "export": "next build && next export",
     "lint": "next lint",
     "test": "jest --watch",
     "cypress": "cypress open"


### PR DESCRIPTION
## Problem:

Vercel preview page says that;

> The current domain is not authorized for OAuth operations. This will prevent signInWithPopup, signInWithRedirect, linkWithPopup and linkWithRedirect from working. Add your domain (workstats-5erzshygc-workstats.vercel.app) to the OAuth redirect domains list in the Firebase console -> Auth section -> Sign in method tab.

![image](https://user-images.githubusercontent.com/4620828/168529137-900dced7-5120-4244-bb1a-3c06b7764ee4.png)

After registering above, then this error occurred;

> 'Failed to parse private key: Error: Invalid PEM formatted message.'

![image](https://user-images.githubusercontent.com/4620828/168557092-4b2ed3ab-4a2b-4ec7-babc-1cc0ffa74248.png)

## Solution:

Applied this solution;
https://github.com/gladly-team/next-firebase-auth/discussions/95

## Evidences:

Confirmed this changes worked well with vercel preview page!!

![image](https://user-images.githubusercontent.com/4620828/168558703-865ed1bb-51bc-4044-afcc-67a090177e87.png)

## Caveats:

Nothing

## References:

https://github.com/gladly-team/next-firebase-auth/discussions/95
