### PR TITLE
Disabled a function to specify period of terms for production env

### DIFF
--- a/components/buttons/ButtonList.tsx
+++ b/components/buttons/ButtonList.tsx
@@ -1,15 +1,22 @@
-import SpecifyPeriodLastWeek from './SpecifyPeriodLastWeek';
+import SpecifyPeriodFixedTerm from './SpecifyPeriodFixedTerm';
 
 const ButtonList = () => {
   return (
     <div>
-      <h2 className='text-xl mt-4 mb-2 px-5'>Select a time period</h2>
+      <h2 className='text-xl mt-4 mb-2 px-5'>Select a time period (WIP)</h2>
       <div className='flex mt-4 px-2'>
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
+        <SpecifyPeriodFixedTerm
+          label='Full'
+          disabled={true}
+          bgColor='bg-gray-500'
+          textColor='white'
+        />
+        <SpecifyPeriodFixedTerm label='This Year' disabled={true} />
+        <SpecifyPeriodFixedTerm label='Last Year' disabled={true} />
+        <SpecifyPeriodFixedTerm label='This Month' disabled={true} />
+        <SpecifyPeriodFixedTerm label='Last Month' disabled={true} />
+        <SpecifyPeriodFixedTerm label='This Week' disabled={true} />
+        <SpecifyPeriodFixedTerm label='Last Week' disabled={true} />
       </div>
     </div>
   );

--- a/components/buttons/SpecifyPeriodFixedTerm.tsx
+++ b/components/buttons/SpecifyPeriodFixedTerm.tsx
@@ -1,0 +1,24 @@
+interface SpecifyPeriodFixedTermTypes {
+  bgColor?: string;
+  disabled?: boolean;
+  label: string;
+  textColor?: string;
+}
+
+const SpecifyPeriodFixedTerm = ({
+  bgColor = 'bg-white',
+  disabled = false,
+  label,
+  textColor = 'slate-800'
+}: SpecifyPeriodFixedTermTypes) => {
+  return (
+    <button
+      disabled={disabled}
+      className={`rounded-lg ${bgColor} shadow text-${textColor} px-3 py-1 mx-2 my-1`}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default SpecifyPeriodFixedTerm;

--- a/components/buttons/SpecifyPeriodFromTo.tsx
+++ b/components/buttons/SpecifyPeriodFromTo.tsx
@@ -28,6 +28,7 @@ const SpecifyPeriodFromTo = () => {
         </div>
         <input
           // datepicker
+          disabled // Temporarily disabled
           type='text'
           className='bg-white text-gray-700 border border-gray-300 rounded-lg block w-44 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 px-2 py-1 pl-10'
           placeholder='mm/dd/yyyy'
@@ -51,6 +52,7 @@ const SpecifyPeriodFromTo = () => {
         </div>
         <input
           // datepicker
+          disabled // Temporarily disabled
           type='text'
           className='bg-white text-gray-700 border border-gray-300 rounded-lg block w-44 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 px-2 py-1 pl-10'
           placeholder='mm/dd/yyyy'

--- a/components/buttons/SpecifyPeriodLastWeek.tsx
+++ b/components/buttons/SpecifyPeriodLastWeek.tsx
@@ -1,9 +1,0 @@
-const SpecifyPeriodLastWeek = () => {
-  return (
-    <button className='rounded-lg bg-white shadow text-slate-800 hover:bg-gray-500 hover:text-white px-3 py-1 mx-2 my-1'>
-      Last week
-    </button>
-  );
-};
-
-export default SpecifyPeriodLastWeek;

--- a/components/cards/NumberOfPullRequests.tsx
+++ b/components/cards/NumberOfPullRequests.tsx
@@ -43,7 +43,7 @@ const NumberOfPullRequests = ({
           </div>
         </div>
         <div>
-          <div className='text-gray-400'># of PRs</div>
+          <div className='text-gray-400'># of pull reqs</div>
           <div className=' text-2xl font-bold text-gray-900'>{data} times</div>
         </div>
       </div>


### PR DESCRIPTION
## Problem:

Originally, we had only prepared a view with buttons for period selection, etc., and it was not in working condition. Since we finally released the web app to the public, I couldn't just leave it there.

## Solution:

I left the view itself in a state where all periods were selected and no other periods could be selected.

## Evidences:

![image](https://user-images.githubusercontent.com/4620828/168609928-afc88447-2a70-444b-a300-5cec814fbad2.png)

## Caveats:

No

## References:

No
