### PR TITLE
Enabled 'Contact Us' button in sidebar

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 
 
-## Evidences:
+## Evidence:
 
 
 

--- a/components/buttons/ButtonList.tsx
+++ b/components/buttons/ButtonList.tsx
@@ -1,15 +1,22 @@
-import SpecifyPeriodLastWeek from './SpecifyPeriodLastWeek';
+import SpecifyPeriodFixedTerm from './SpecifyPeriodFixedTerm';
 
 const ButtonList = () => {
   return (
     <div>
-      <h2 className='text-xl mt-4 mb-2 px-5'>Select a time period</h2>
+      <h2 className='text-xl mt-4 mb-2 px-5'>Select a time period (WIP)</h2>
       <div className='flex mt-4 px-2'>
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
-        <SpecifyPeriodLastWeek />
+        <SpecifyPeriodFixedTerm
+          label='Full'
+          disabled={true}
+          bgColor='bg-gray-500'
+          textColor='white'
+        />
+        <SpecifyPeriodFixedTerm label='This Year' disabled={true} />
+        <SpecifyPeriodFixedTerm label='Last Year' disabled={true} />
+        <SpecifyPeriodFixedTerm label='This Month' disabled={true} />
+        <SpecifyPeriodFixedTerm label='Last Month' disabled={true} />
+        <SpecifyPeriodFixedTerm label='This Week' disabled={true} />
+        <SpecifyPeriodFixedTerm label='Last Week' disabled={true} />
       </div>
     </div>
   );

--- a/components/buttons/SpecifyPeriodFixedTerm.tsx
+++ b/components/buttons/SpecifyPeriodFixedTerm.tsx
@@ -1,0 +1,24 @@
+interface SpecifyPeriodFixedTermTypes {
+  bgColor?: string;
+  disabled?: boolean;
+  label: string;
+  textColor?: string;
+}
+
+const SpecifyPeriodFixedTerm = ({
+  bgColor = 'bg-white',
+  disabled = false,
+  label,
+  textColor = 'slate-800'
+}: SpecifyPeriodFixedTermTypes) => {
+  return (
+    <button
+      disabled={disabled}
+      className={`rounded-lg ${bgColor} shadow text-${textColor} px-3 py-1 mx-2 my-1`}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default SpecifyPeriodFixedTerm;

--- a/components/buttons/SpecifyPeriodFromTo.tsx
+++ b/components/buttons/SpecifyPeriodFromTo.tsx
@@ -28,6 +28,7 @@ const SpecifyPeriodFromTo = () => {
         </div>
         <input
           // datepicker
+          disabled // Temporarily disabled
           type='text'
           className='bg-white text-gray-700 border border-gray-300 rounded-lg block w-44 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 px-2 py-1 pl-10'
           placeholder='mm/dd/yyyy'
@@ -51,6 +52,7 @@ const SpecifyPeriodFromTo = () => {
         </div>
         <input
           // datepicker
+          disabled // Temporarily disabled
           type='text'
           className='bg-white text-gray-700 border border-gray-300 rounded-lg block w-44 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 px-2 py-1 pl-10'
           placeholder='mm/dd/yyyy'

--- a/components/buttons/SpecifyPeriodLastWeek.tsx
+++ b/components/buttons/SpecifyPeriodLastWeek.tsx
@@ -1,9 +1,0 @@
-const SpecifyPeriodLastWeek = () => {
-  return (
-    <button className='rounded-lg bg-white shadow text-slate-800 hover:bg-gray-500 hover:text-white px-3 py-1 mx-2 my-1'>
-      Last week
-    </button>
-  );
-};
-
-export default SpecifyPeriodLastWeek;

--- a/components/cards/NumberOfPullRequests.tsx
+++ b/components/cards/NumberOfPullRequests.tsx
@@ -43,7 +43,7 @@ const NumberOfPullRequests = ({
           </div>
         </div>
         <div>
-          <div className='text-gray-400'># of PRs</div>
+          <div className='text-gray-400'># of pull reqs</div>
           <div className=' text-2xl font-bold text-gray-900'>{data} times</div>
         </div>
       </div>

--- a/components/common/Sidebar.tsx
+++ b/components/common/Sidebar.tsx
@@ -73,11 +73,14 @@ const Sidebar = () => {
             Privacy Policy
           </a>
         </Link>
-        <Link href='/contact-us'>
-          <a className='block py-2 px-4 rounded hover:bg-gray-700 hover:text-white'>
-            Contact Us
-          </a>
-        </Link>
+        <a
+          className='block py-2 px-4 rounded hover:bg-gray-700 hover:text-white'
+          href='mailto: info@suchica.com?subject=WorkStats Feedback'
+          target='_blank'
+          rel='noreferrer noopener' // Must pair with target='_blank'
+        >
+          Contact Us
+        </a>
         {/* <Link href="/company">
           <a className="block py-2 px-4 rounded hover:bg-gray-700 hover:text-white">
             Company


### PR DESCRIPTION
## Problem:

'Contact Us' button in sidebar was not working, and it led users to 404 page.

## Solution:

Enabled 'Contact Us' button in sidebar to open a mailer like Gmail in a new tab.

## Evidence:

![image](https://user-images.githubusercontent.com/4620828/168740126-fd3806b8-c5a3-4e0d-907a-97442ff6cf25.png)

## Caveats:

I really wanted to create markdown-like headings for the body content as well, but I didn't know how to do it, so I decided not to set any body in particular.

## References:

No
