### PR TITLE
Resolved mis-configuration for sitemap location

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "postbuild": "next-sitemap --config sitemap.config.js",
-    "start": "next build && next-sitemap --config sitemap.config.js && next start",
+    "start": "next build && next start",
     "lint": "next lint",
     "test": "jest --watch",
     "cypress": "cypress open"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://workstats.dev/
+
+# Sitemaps
+Sitemap: https://workstats.dev/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
+<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
+<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
+<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
+<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.409Z</lastmod></url>
+</urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://workstats.dev/sitemap-0.xml</loc></sitemap>
+</sitemapindex>

--- a/sitemap.config.js
+++ b/sitemap.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteUrl: 'https://workstats.dev/',
   generateRobotsTxt: true, // Generate robots.txt, default is false
-  sitemapSize: 7000, // Split sitemap into multiple files, default is 5000
-  outDir: './out'
+  sitemapSize: 7000 // Split sitemap into multiple files, default is 5000
+  // outDir: './out' // If we use both SSG and SSR, we can't use `next export` and the directory of `./out`
 };


### PR DESCRIPTION
## Problem:

Could not open https://workstats.dev/sitemap.xml and it gave me a 404 page.

## Solution:

Changed output directory setting in sitemap.config.js because ./out directory is for `next export` which is used for only static web applications.

## Evidence:

sitemap pages were successfully displayed this time.

![image](https://user-images.githubusercontent.com/4620828/169648138-ea0f6fce-eea7-4132-8d54-ff61e43641c1.png)
![image](https://user-images.githubusercontent.com/4620828/169648140-2f16c846-36dc-44a1-a6c7-b430cdd08239.png)

## Caveats:



## References:


