### PR TITLE
Added a page to cancel user's membership and feedback why the user wanted to leave

### DIFF
--- a/components/buttons/CheckButton.tsx
+++ b/components/buttons/CheckButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface CheckButtonProps {
+  id: string;
+  label: string;
+  checked?: boolean;
+}
+
+const CheckButton = ({ id, label, checked }: CheckButtonProps) => {
+  return (
+    <div className='check-button flex hover:bg-amber-100 mt-1 py-0.5 px-2 rounded-lg place-items-center'>
+      <input
+        type='checkbox'
+        id={id}
+        name={label}
+        checked={checked}
+        className=''
+      />
+      <label htmlFor={id} className='flex-1 text-slate-800 text-base px-2'>
+        {label}
+      </label>
+    </div>
+  );
+};
+
+export default CheckButton;

--- a/components/buttons/SendFeedbackButton.tsx
+++ b/components/buttons/SendFeedbackButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const SendFeedbackButton = () => {
+  return (
+    <button
+      type='submit'
+      className='w-auto h-8 bg-gray-800 text-blue-100 hover:bg-gray-700 hover:text-white font-bold mt-4 py-1 px-3 rounded-lg'
+    >
+      Send your feedback to us
+    </button>
+  );
+};
+
+export default SendFeedbackButton;

--- a/components/buttons/UnsubscribeButton.tsx
+++ b/components/buttons/UnsubscribeButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import handleSubmitCancelMembership from '../../services/deleteUserDocInFirestore';
+
+interface UnsubscribeButtonTypes {
+  uid: string;
+  disabled: boolean;
+}
+
+const UnsubscribeButton = ({ uid, disabled }: UnsubscribeButtonTypes) => {
+  console.log('disabled in the button: ', disabled);
+  return (
+    <>
+      {disabled ? (
+        <p className='py-1 text-red-600'>
+          It enables this button below to submit the survey before.
+        </p>
+      ) : (
+        <p className='py-1 text-red-600'>
+          Now you can click this button below.
+        </p>
+      )}
+      <button
+        type='submit'
+        className='w-auto h-8 bg-red-500 hover:bg-red-700 text-white font-bold mt-4 py-1 px-3 rounded-lg'
+        disabled={disabled}
+        onClick={async () => await handleSubmitCancelMembership(uid)}
+      >
+        Delete My Account and Data Permanently
+      </button>
+    </>
+  );
+};
+
+export default UnsubscribeButton;

--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -21,7 +21,7 @@ import GoogleCalendarIcon from '../../public/google-calendar-svgrepo-com.svg';
 import GitHubIcon2 from '../../public/github-svgrepo-com.svg';
 
 // Custom services
-import { createUserDoc } from '../../services/setUserDocToFirestore';
+import { createUserDoc } from '../../services/setDocToFirestore';
 
 // Scopes in detail: https://developers.google.com/identity/protocols/oauth2/scopes#calendar
 const scopes = 'https://www.googleapis.com/auth/calendar.readonly	';
@@ -32,12 +32,8 @@ const Login = () => {
   const loginWithGoogle = () => {
     signInWithPopup(auth, googleProvider)
       .then((result) => {
-        // console.log('result is: ', result);
         // This gives you a Google Access Token. You can use it to access the Google API.
-        // const credential = GoogleAuthProvider.credentialFromResult(result);
-        // console.log('credential is: ', credential);
         const user = result.user;
-        // console.log('user is: ', user);
         createUserDoc(user.uid);
         window.location.reload();
       })
@@ -62,11 +58,7 @@ const Login = () => {
   const loginWithGithub = () => {
     signInWithPopup(auth, githubProvider)
       .then((result) => {
-        // console.log('result is: ', result);
-        // const credential = GithubAuthProvider.credentialFromResult(result);
-        // console.log('credential is: ', credential);
         const user = result.user;
-        // console.log('user is: ', user);
         createUserDoc(user.uid);
         window.location.reload();
       })

--- a/pages/cancel-membership.tsx
+++ b/pages/cancel-membership.tsx
@@ -1,0 +1,148 @@
+// React and Next.js
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import React, { useState } from 'react';
+import nookies from 'nookies';
+import Head from 'next/head';
+
+// Firebase related
+import { verifyIdToken } from '../firebaseAdmin';
+import getAUserDoc from '../services/getAUserDocFromFirebase';
+import { UserType } from '../config/firebaseTypes';
+
+// Components and Services
+import CheckButton from '../components/buttons/CheckButton';
+import UnsubscribeButton from '../components/buttons/UnsubscribeButton';
+import SendFeedbackButton from '../components/buttons/SendFeedbackButton';
+import { handleSubmitSurveyWhyYouLeave } from '../services/setDocToFirestore';
+
+interface CancelMembershipTypes {
+  uid: string;
+  userDoc: UserType | null;
+}
+
+const useCancelMembership = ({ uid }: CancelMembershipTypes) => {
+  const [isSurveySubmitted, setIsSurveySubmitted] = useState(false);
+  console.log('isSurveySubmitted: ', isSurveySubmitted);
+  console.log('!isSurveySubmitted: ', !isSurveySubmitted);
+  return (
+    <>
+      <Head>
+        <title>Cancel Membership - WorkStats</title>
+        <meta name='description' content='WorkStats' />
+        <link rel='icon' href='/favicon.ico' />
+      </Head>
+      <main className='px-5'>
+        <h1 className='text-3xl py-4'>Cancel Membership</h1>
+        <p className='py-1'>
+          I am very sorry that you wish to unsubscribe from this service. There
+          is a button to unsubscribe at the end of this page, but before you do,
+          could you please tell us why you were not satisfied with this service
+          and what made you decide to unsubscribe? We would like to take this
+          seriously and make improvements.
+        </p>
+        <h2 className='text-2xl py-4'>1. Tell us why you leave.</h2>
+        <p className='py-1'>
+          What are the applicable reasons for withdrawal from this service? You
+          may select more than one.
+        </p>
+        <form
+          name='survey why the user wanted to leave'
+          onSubmit={async (e) => {
+            console.log('e.target', e.currentTarget.reason1.id);
+            await handleSubmitSurveyWhyYouLeave(e, uid, 13);
+            setIsSurveySubmitted(true);
+          }}
+          method='post'
+          target='_self'
+          autoComplete='off'
+        >
+          <CheckButton id='reason1' label='I do not use GitHub.' />
+          <CheckButton id='reason2' label='I do not use Asana.' />
+          <CheckButton id='reason3' label='I do not use Slack.' />
+          <CheckButton
+            id='reason4'
+            label='I use GitHub, but I do not have any GitHub public repository that I contribute to.'
+          />
+          <CheckButton
+            id='reason5'
+            label='I use Asana, but I am not authorized to issue Asana Personal Access Token and do not know Asana administrator.'
+          />
+          <CheckButton
+            id='reason6'
+            label='I asked Asana administrator to give me Asana Personal Access Token, but I was refused.'
+          />
+          <CheckButton
+            id='reason7'
+            label='I have Asana Personal Access Token, but I do not want to share it with this app.'
+          />
+          <CheckButton
+            id='reason8'
+            label='I use Slack, but I am not authorized to issue User Token and do not know Slack administrator.'
+          />
+          <CheckButton
+            id='reason9'
+            label='I asked Slack administrator to give me User Token, but I was refused.'
+          />
+          <CheckButton
+            id='reason10'
+            label='I have Slack User Token, but I do not want to share it with this app.'
+          />
+          <CheckButton
+            id='reason11'
+            label='I do not want to care about these numbers in the first place.'
+          />
+          <CheckButton
+            id='reason12'
+            label='I do not know how to use these numbers.'
+          />
+          <CheckButton
+            id='reason13'
+            label='Not enough variety in numbers are tabulated.'
+          />
+          <SendFeedbackButton />
+        </form>
+        {isSurveySubmitted ? (
+          <p className='py-3'>
+            The survey has been submitted. Thank you for your feedback. If you
+            would like to correct the reason for your withdrawal, please modify
+            the checkboxes above and resubmit your request.
+          </p>
+        ) : null}
+        <h2 className='text-2xl py-4'>
+          2. Cancel membership and delete your data.
+        </h2>
+        <p className='py-1'>
+          When you unsubscribe, your data will be erased and your account will
+          be deleted. If you try to log in again, the account will be created
+          again, but unlike before, you should not see any data and there should
+          be no data in your user settings. That way you can confirm that your
+          data has indeed been deleted.
+        </p>
+        <p className='py-1'>
+          Therefore, even if you have accidentally unsubscribed, you will not be
+          able to restore your account or data. Please be aware of this.
+        </p>
+        <UnsubscribeButton uid={uid} disabled={!isSurveySubmitted} />
+        <div className='h-20'></div>
+      </main>
+    </>
+  );
+};
+
+export default useCancelMembership;
+
+export const getServerSideProps: GetServerSideProps = async (
+  ctx: GetServerSidePropsContext
+) => {
+  const cookies = nookies.get(ctx);
+  if (cookies.token) {
+    const token = await verifyIdToken(cookies.token);
+    const { uid } = token;
+    const userDoc = (await getAUserDoc(uid)) ? await getAUserDoc(uid) : null;
+    return {
+      props: { uid, userDoc }
+    };
+  } else {
+    return { props: {} as never };
+  }
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -115,17 +115,13 @@ export default function Home({
 export const getServerSideProps: GetServerSideProps = async (
   ctx: GetServerSidePropsContext
 ) => {
-  // console.log('ctx is: ', ctx);
   const cookies = nookies.get(ctx);
-  // console.log('cookies is: ', cookies);
 
   if (cookies.token) {
     const token = await verifyIdToken(cookies.token);
 
     // the user is authenticated!
     const { uid } = token;
-    // const currentUser = auth.currentUser;
-    // const docId = currentUser?.uid ? currentUser.uid : '';
     const userDoc = await getAUserDoc(uid);
 
     // Profile list to be displayed on the left side

--- a/pages/user-settings.tsx
+++ b/pages/user-settings.tsx
@@ -1,6 +1,8 @@
 // Frameworks and libraries
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
+import Link from 'next/link';
+import Image from 'next/image';
 import nookies from 'nookies';
 
 // Components and others
@@ -15,10 +17,16 @@ import {
   handleSubmitCommunicationActivity,
   handleSubmitSourceCode,
   handleSubmitTaskTicket
-} from '../services/setUserDocToFirestore';
+} from '../services/setDocToFirestore';
 import QuestionMark from '../components/common/QuestionMark';
+import NewTabIcon from '../public/new-tab-svgrepo-com.svg';
 
-const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
+interface UserSettingsProps {
+  uid: string;
+  userDoc: UserType | null;
+}
+
+const userSettings = ({ uid, userDoc }: UserSettingsProps) => {
   return (
     <>
       <Head>
@@ -56,63 +64,63 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
               name={'firstName'}
               placeholder={'Oliver'}
               width={32}
-              value={userDoc.firstName}
+              value={userDoc?.firstName}
             />
             <InputBox
               label={'Middle Name'}
               name={'middleName'}
               placeholder={'Alan'}
               width={36}
-              value={userDoc.middleName}
+              value={userDoc?.middleName}
             />
             <InputBox
               label={'Last Name'}
               name={'lastName'}
               placeholder={'Smith'}
               width={36}
-              value={userDoc.lastName}
+              value={userDoc?.lastName}
             />
             <InputBox
               label={'Department'}
               name={'department'}
               placeholder={'IT & Development'}
               width={96}
-              value={userDoc.department}
+              value={userDoc?.department}
             />
             <InputBox
               label={'Rank'}
               name={'rank'}
               placeholder={'Director'}
               width={36}
-              value={userDoc.rank}
+              value={userDoc?.rank}
             />
             <InputBox
               label={'Supervisor'}
               name={'supervisor'}
               placeholder={'A name here'}
               width={36}
-              value={userDoc.supervisor}
+              value={userDoc?.supervisor}
             />
             <InputBox
               label={'Assessor'}
               name={'assessor'}
               placeholder={'A name here'}
               width={36}
-              value={userDoc.assessor}
+              value={userDoc?.assessor}
             />
             <InputBox
               label={'Assigned Project'}
               name={'assignedPj'}
               placeholder={'New Business Development'}
               width={96}
-              value={userDoc.assignedPj}
+              value={userDoc?.assignedPj}
             />
             <InputBox
               label={'Role'}
               name={'role'}
               placeholder={'Product Manager'}
               width={36}
-              value={userDoc.role}
+              value={userDoc?.role}
             />
             <SubmitButton />
           </form>
@@ -139,14 +147,14 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
             inputType={'number'}
             placeholder={'4620828'}
             width={36}
-            value={userDoc.github?.userId}
+            value={userDoc?.github?.userId}
           />
           <InputBox
             label={'User Name'}
             name={'githubUserName'}
             placeholder={'oliversmith'}
             width={36}
-            value={userDoc.github?.userName}
+            value={userDoc?.github?.userName}
           />
         </div>
         <div className='flex flex-wrap items-center'>
@@ -156,21 +164,21 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
             name={'githubRepoOwner1'}
             placeholder={'octocat'}
             width={36}
-            value={userDoc.github?.repositories[0]?.owner}
+            value={userDoc?.github?.repositories[0]?.owner}
           />
           <InputBox
             label={'Repo Name'}
             name={'githubRepo1'}
             placeholder={'hello-world'}
             width={36}
-            value={userDoc.github?.repositories[0]?.repo}
+            value={userDoc?.github?.repositories[0]?.repo}
           />
           <InputBox
             label={'Repo Visibility'}
             name={'githubRepoVisibility1'}
             placeholder={'Public or Private'}
             width={36}
-            value={userDoc.github?.repositories[0]?.visibility}
+            value={userDoc?.github?.repositories[0]?.visibility}
           />
         </div>
         <div className='flex flex-wrap items-center'>
@@ -180,21 +188,21 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
             name={'githubRepoOwner2'}
             placeholder={'octocat'}
             width={36}
-            value={userDoc.github?.repositories[1]?.owner}
+            value={userDoc?.github?.repositories[1]?.owner}
           />
           <InputBox
             label={'Repo Name'}
             name={'githubRepo2'}
             placeholder={'hello-world'}
             width={36}
-            value={userDoc.github?.repositories[1]?.repo}
+            value={userDoc?.github?.repositories[1]?.repo}
           />
           <InputBox
             label={'Repo Visibility'}
             name={'githubRepoVisibility2'}
             placeholder={'Public or Private'}
             width={36}
-            value={userDoc.github?.repositories[1]?.visibility}
+            value={userDoc?.github?.repositories[1]?.visibility}
           />
           <SubmitButton />
         </div>
@@ -220,7 +228,7 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
             inputType={'number'}
             placeholder={'1200781652740141'}
             width={48}
-            value={userDoc.asana?.userId}
+            value={userDoc?.asana?.userId}
           />
         </div>
         <div className='flex flex-wrap items-center'>
@@ -231,21 +239,21 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
             inputType={'number'}
             placeholder={'1234567890123456'}
             width={48}
-            value={userDoc.asana?.workspace[0]?.workspaceId}
+            value={userDoc?.asana?.workspace[0]?.workspaceId}
           />
           <InputBox
             label={'Workspace Name'}
             name={'asanaWorkspaceName1'}
             placeholder={'Suchica'}
             width={36}
-            value={userDoc.asana?.workspace[0]?.workspaceName}
+            value={userDoc?.asana?.workspace[0]?.workspaceName}
           />
           <InputBox
             label={'Personal Access Token'}
             name={'asanaWorkspacePersonalAccessToken1'}
             placeholder={'1/1234567890123456:031..........................a63'}
             width={96}
-            value={userDoc.asana?.workspace[0]?.personalAccessToken}
+            value={userDoc?.asana?.workspace[0]?.personalAccessToken}
           />
         </div>
         <div className='flex flex-wrap items-center'>
@@ -256,21 +264,21 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
             inputType={'number'}
             placeholder={'1234567890123456'}
             width={48}
-            value={userDoc.asana?.workspace[1]?.workspaceId}
+            value={userDoc?.asana?.workspace[1]?.workspaceId}
           />
           <InputBox
             label={'Workspace Name'}
             name={'asanaWorkspaceName2'}
             placeholder={'Suchica'}
             width={36}
-            value={userDoc.asana?.workspace[1]?.workspaceName}
+            value={userDoc?.asana?.workspace[1]?.workspaceName}
           />
           <InputBox
             label={'Personal Access Token'}
             name={'asanaWorkspacePersonalAccessToken2'}
             placeholder={'1/1234567890123456:031..........................a63'}
             width={96}
-            value={userDoc.asana?.workspace[1]?.personalAccessToken}
+            value={userDoc?.asana?.workspace[1]?.personalAccessToken}
           />
           <SubmitButton />
         </div>
@@ -296,14 +304,14 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
               name={'slackWorkspaceName1'}
               placeholder={'Suchica'}
               width={36}
-              value={userDoc.slack?.workspace[0]?.workspaceName}
+              value={userDoc?.slack?.workspace[0]?.workspaceName}
             />
             <InputBox
               label={'Member ID'}
               name={'slackWorkspaceMemberId1'}
               placeholder={'U02DK80DN9H'}
               width={36}
-              value={userDoc.slack?.workspace[0]?.memberId}
+              value={userDoc?.slack?.workspace[0]?.memberId}
             />
             <InputBox
               label={'User Token'}
@@ -312,7 +320,7 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
                 'xoxp-1234567890123-1234567890123-1234567890123-a94..........................16e'
               }
               width={96}
-              value={userDoc.slack?.workspace[0]?.userToken}
+              value={userDoc?.slack?.workspace[0]?.userToken}
             />
             <InputBox
               label={'Bot Token'}
@@ -321,7 +329,7 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
                 'xoxb-1234567890123-1234567890123-Uia..................8HH'
               }
               width={96}
-              value={userDoc.slack?.workspace[0]?.botToken}
+              value={userDoc?.slack?.workspace[0]?.botToken}
             />
           </div>
         </div>
@@ -333,14 +341,14 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
               name={'slackWorkspaceName2'}
               placeholder={'Suchica'}
               width={36}
-              value={userDoc.slack?.workspace[1]?.workspaceName}
+              value={userDoc?.slack?.workspace[1]?.workspaceName}
             />
             <InputBox
               label={'Member ID'}
               name={'slackWorkspaceMemberId2'}
               placeholder={'U02DK80DN9H'}
               width={36}
-              value={userDoc.slack?.workspace[1]?.memberId}
+              value={userDoc?.slack?.workspace[1]?.memberId}
             />
             <InputBox
               label={'User Token'}
@@ -349,7 +357,7 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
                 'xoxp-1234567890123-1234567890123-1234567890123-a94..........................16e'
               }
               width={96}
-              value={userDoc.slack?.workspace[1]?.userToken}
+              value={userDoc?.slack?.workspace[1]?.userToken}
             />
             <InputBox
               label={'Bot Token'}
@@ -358,12 +366,41 @@ const userSettings = ({ uid, userDoc }: { uid: string; userDoc: UserType }) => {
                 'xoxb-1234567890123-1234567890123-Uia..................8HH'
               }
               width={96}
-              value={userDoc.slack?.workspace[1]?.botToken}
+              value={userDoc?.slack?.workspace[1]?.botToken}
             />
             <SubmitButton />
           </div>
         </div>
       </form>
+      <div className='flex'>
+        <Link href='/cancel-membership'>
+          <a
+            className='mr-3'
+            target='_blank'
+            rel='noreferrer noopener' // Must pair with target='_blank'
+          >
+            <button className='text-xl mt-8 mb-2 ml-6 underline underline-offset-4'>
+              Cancel Membership
+            </button>
+          </a>
+        </Link>
+        <div className='mt-9 mb-1'>
+          <Image
+            src={NewTabIcon}
+            width={24}
+            height={24}
+            layout='intrinsic'
+            alt='Open a new tab'
+            quality={75}
+            priority={false}
+            placeholder='empty'
+          />
+        </div>
+      </div>
+      <p className='py-1 ml-6'>
+        If you wish to cancel your membership to this service, please follow
+        this link.
+      </p>
       <div className='h-20'></div>
     </>
   );
@@ -378,7 +415,7 @@ export const getServerSideProps: GetServerSideProps = async (
   if (cookies.token) {
     const token = await verifyIdToken(cookies.token);
     const { uid } = token;
-    const userDoc = await getAUserDoc(uid);
+    const userDoc = (await getAUserDoc(uid)) ? await getAUserDoc(uid) : null;
     return {
       props: { uid, userDoc }
     };

--- a/public/new-tab-svgrepo-com.svg
+++ b/public/new-tab-svgrepo-com.svg
@@ -1,0 +1,15 @@
+<svg width="32px" height="32px" viewBox="0 0 32 32" id="icon" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: none;
+      }
+    </style>
+  </defs>
+  <g>
+    <path d="M26,26H6V6H16V4H6A2.002,2.002,0,0,0,4,6V26a2.002,2.002,0,0,0,2,2H26a2.002,2.002,0,0,0,2-2V16H26Z"/>
+    <path d="M26,26H6V6H16V4H6A2.002,2.002,0,0,0,4,6V26a2.002,2.002,0,0,0,2,2H26a2.002,2.002,0,0,0,2-2V16H26Z"/>
+  </g>
+  <polygon points="26 6 26 2 24 2 24 6 20 6 20 8 24 8 24 12 26 12 26 8 30 8 30 6 26 6"/>
+  <rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
+</svg>

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
-<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
-<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
-<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.408Z</lastmod></url>
-<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-21T10:36:41.409Z</lastmod></url>
+<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.517Z</lastmod></url>
+<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
 </urlset>

--- a/services/asanaServices.client.tsx
+++ b/services/asanaServices.client.tsx
@@ -40,11 +40,13 @@ const useNumberOfTasks = (
       headers: myHeaders
     }).then((res) => res.json());
 
-    const numberOfAll: number = response.data.length;
+    const numberOfAll: number = response.data?.length
+      ? response.data.length
+      : 0;
 
-    const numberOfClosed: number = response['data'].filter((item: item) => {
+    const numberOfClosed: number = response['data']?.filter((item: item) => {
       return item['completed'] === true;
-    }).length;
+    })?.length;
 
     const output = {
       numberOfAll: numberOfAll,
@@ -60,7 +62,7 @@ const useNumberOfTasks = (
   });
 
   if (error) {
-    console.log(`Failed to load: ${error}`);
+    console.log(`Failed to load Asana data: ${error}`);
     return 0;
   } else if (!data) {
     // console.log('Loading stats of asana...');

--- a/services/deleteUserDocInFirestore.ts
+++ b/services/deleteUserDocInFirestore.ts
@@ -1,0 +1,72 @@
+import { deleteUser, reauthenticateWithPopup } from 'firebase/auth';
+import { deleteDoc, doc } from 'firebase/firestore';
+import {
+  auth,
+  db,
+  githubProvider,
+  googleProvider
+} from '../config/firebaseClient';
+
+// const user = auth.currentUser;
+const handleSubmitCancelMembership = async (docId: string) => {
+  // Confirm user wants to cancel membership
+  const confirm = window.confirm(
+    'Are you sure you want to cancel your membership?'
+  );
+  if (confirm) {
+    // Delete a user document in Firestore User collection first.
+    const docRef = doc(db, 'users', docId);
+    deleteDoc(docRef)
+      .then(() => {
+        alert('Your user information has been deleted.');
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+
+    // Then delete a user account from firebase authentication.
+    auth.onAuthStateChanged(async (user) => {
+      if (user) {
+        deleteUser(user)
+          .then(() => {
+            alert('User account has been deleted successfully!!');
+          })
+          .catch((error) => {
+            // If the user has signed in too long ago, deleting the user will fail. In this case, we have to reauthenticate the user with their credential.
+            if (error.code === 'auth/requires-recent-login') {
+              let provider = googleProvider;
+              if (user.providerData[0].providerId === 'github.com') {
+                provider = githubProvider;
+              }
+              reauthenticateWithPopup(user, provider)
+                .then(() => {
+                  deleteUser(user)
+                    .then(() => {
+                      alert('User account has been deleted successfully!!');
+                      window.location.reload();
+                    })
+                    .catch((error) => {
+                      console.log(
+                        'User deletion failed despite re-authentication.',
+                        error
+                      );
+                    });
+                })
+                .catch((error) => {
+                  console.log('User re-authentication itself failed.', error);
+                });
+            } else {
+              console.log(
+                'User deletion failed for reasons other than "auth/requires-recent-login".',
+                error
+              );
+            }
+          });
+      } else {
+        return;
+      }
+    });
+  }
+};
+
+export default handleSubmitCancelMembership;

--- a/services/githubServices.client.tsx
+++ b/services/githubServices.client.tsx
@@ -18,22 +18,23 @@ const useNumberOfCommits = (
 ) => {
   // console.log(`githubUserId is: ${githubUserId}`);
   const url = `${base}/repos/${owner}/${repo}/stats/contributors`;
-  // console.log(url);
+  if (owner === null || repo === null || githubUserId === 0) {
+    return 0;
+  }
   const headers = new Headers();
   headers.append('Accept', 'application/vnd.github.v3+json');
   const fetcher = async (url: string) => {
     const response = await fetch(url, {
       headers: headers
     }).then((res) => res.json());
-    // console.log(`response is: ${JSON.stringify(response)}`);
     // @ts-ignore
     const filteredResponse = response.filter((item) => {
       return item.author.id === githubUserId;
     });
-    // console.log(filteredResponse);
     const output: number = filteredResponse[0].total;
     return output;
   };
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data, error } = useSWR(url, fetcher, options);
 
   if (error) {
@@ -61,7 +62,9 @@ const useNumberOfPullRequests = (
   };
   let query = new URLSearchParams(params);
   const url = `${base}/repos/${owner}/${repo}/pulls?${query}`;
-  // console.log(url);
+  if (owner === null || repo === null || githubUserId === 0) {
+    return 0;
+  }
 
   // use useSWR function in Next.js
   // The official document is here: https://swr.vercel.app/docs/data-fetching
@@ -85,15 +88,11 @@ const useNumberOfPullRequests = (
       params.page = pageCount.toString();
       query = new URLSearchParams(params);
       url = `${base}/repos/${owner}/${repo}/pulls?${query}`;
-      // console.log(`count is: ${count}`);
-      // console.log(`totalCount is: ${totalCount}`);
-      // console.log(`pageCount is: ${pageCount}`);
-      // console.log(`params.page is: ${params.page}`);
-      // console.log(`url is: ${url}`)
     } while (count > 0);
     return totalCount;
   };
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { data, error } = useSWR(url, fetcher, options);
 
   if (error) {

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -14,9 +14,7 @@ const handleSubmitBasicInfo = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
 ) => {
-  // Stop the form from submitting and refreshing the page.
   event.preventDefault();
-
   const docRef = doc(db, 'users', docId);
   const docData: UserType = {
     assessor: event.currentTarget.assessor.value,
@@ -40,9 +38,7 @@ const handleSubmitSourceCode = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
 ) => {
-  // Stop the form from submitting and refreshing the page.
   event.preventDefault();
-
   const docRef = doc(db, 'users', docId);
   const docData = {
     github: {
@@ -73,9 +69,7 @@ const handleSubmitTaskTicket = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
 ) => {
-  // Stop the form from submitting and refreshing the page.
   event.preventDefault();
-
   const docRef = doc(db, 'users', docId);
   const docData = {
     asana: {
@@ -107,9 +101,7 @@ const handleSubmitCommunicationActivity = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
 ) => {
-  // Stop the form from submitting and refreshing the page.
   event.preventDefault();
-
   const docRef = doc(db, 'users', docId);
   const docData = {
     slack: {
@@ -136,10 +128,36 @@ const handleSubmitCommunicationActivity = async (
   return;
 };
 
+const handleSubmitSurveyWhyYouLeave = async (
+  event: React.FormEvent<HTMLFormElement>,
+  docId: string,
+  n: number
+) => {
+  event.preventDefault();
+  const docRef = doc(db, 'unsub-reasons', docId);
+  const arrayData = Array(n)
+    .fill(0) // fill with 0 because map() will not work with undefined
+    .map((_, i) => {
+      return {
+        reasonId: event.currentTarget[`reason${i + 1}`].id,
+        reasonName: event.currentTarget[`reason${i + 1}`].name,
+        checked: event.currentTarget[`reason${i + 1}`].checked
+      };
+    });
+  const docData = {
+    reasons: arrayData
+  };
+  const option = { merge: true }; // means that if the doc already exists, it will be updated instead of creating a new one.
+
+  await setDoc(docRef, docData, option);
+  return;
+};
+
 export {
   createUserDoc,
   handleSubmitBasicInfo,
   handleSubmitSourceCode,
   handleSubmitTaskTicket,
-  handleSubmitCommunicationActivity
+  handleSubmitCommunicationActivity,
+  handleSubmitSurveyWhyYouLeave
 };

--- a/services/slackServices.server.tsx
+++ b/services/slackServices.server.tsx
@@ -107,10 +107,35 @@ const listTimestampInSlack = async (channel: string, token: string) => {
   return { channel, result };
 };
 
+// Post a message to Slack
+const postMessageToSlack = async () => {
+  // Prepare arguments for the Slack API call
+  const auth = `Bearer ${process.env.NEXT_PUBLIC_SLACK_BOT_TOKEN}`;
+  const slackChannel = 'C03GG1FFZFC'; // channel name is 'cancel-membership'
+  const slackMessage = 'A user has canceled their membership.';
+  // const slackMessage = `
+  // A new user has joined the app!
+  // User name: Test
+  // `;
+  const slackURL = 'https://slack.com/api/chat.postMessage';
+
+  // How to call the Slack API
+  const response = await fetch(slackURL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: `token=${auth}&channel=${slackChannel}&text=${slackMessage}`
+  });
+  const data = await response.json();
+  console.log('data is: ', data);
+};
+
 export {
   slackSearchFromServer,
   slackConversationHistory,
   slackConversationList,
   countRepliesInSlack,
-  listTimestampInSlack
+  listTimestampInSlack,
+  postMessageToSlack
 };


### PR DESCRIPTION
## Problem:

1. Once users logged in, there was no way to delete their accounts or data. This made users feel insecure after logging in and risked making the Service unpopular for users.
2. There was also no place to get feedback on why they were leaving or why they were unsatisfied.

## Solution:

Added a page containing a button for the user to unsubscribe and a button for the user to give us feedback on why they wanted to unsubscribe.

## Evidence:

First, user needs to go to the bottom in user settings page when they want to cancel their membership in this service.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/169770849-ed8078ca-2d8c-4a75-96a3-5b0f6e4538b4.png">

Then Cancel Membership page will show up like this.

![image](https://user-images.githubusercontent.com/4620828/169771081-2818e1fb-27f3-42b5-a592-e0ab4138ddeb.png)

Select some reasons the user felt, then click 'Send your feedback to us' otherwise 'Delete My Account and Data Permanently' is disabled.

![image](https://user-images.githubusercontent.com/4620828/169771537-c728c90d-c7c9-4320-847b-4bb4418a9105.png)

After submitting the survey, now the cancel membership button is enabled

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/169771814-da3e3996-1536-4c08-8018-cece31956de3.png">

And the survey result is posted to firestore like this.

![image](https://user-images.githubusercontent.com/4620828/169772016-676a5722-d960-49f7-a315-62d09320c986.png)

If the user click the button, then confirmation modal will pop up like this

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/169773037-ad8f06f5-959f-49cb-b067-83da9f7de719.png">

If the user click 'OK', then the users' data will be deleted first

![image](https://user-images.githubusercontent.com/4620828/169773138-61cf6be4-16bb-4974-827f-412a3fd90934.png)

Then the user account will be deleted and auth.tsx will be aware of this, then it makes users jump back to login page automatically.

![image](https://user-images.githubusercontent.com/4620828/169773152-a3fff398-8a24-48bb-8069-20bc57ae8bd5.png)

the user document is gone (I was logged in as 
ZohxVTqml2bVbAL5LTi8Tm0eDwv2 but there is not this id anymore)

<img width="495" alt="image" src="https://user-images.githubusercontent.com/4620828/169773963-d33d2810-3539-425f-ad5a-e53e70a4cd02.png">

![image](https://user-images.githubusercontent.com/4620828/169774433-c80b2912-c3f8-422f-83ae-808979669f41.png)

## Caveats:

1. This PR does not send the survey result to Slack now, I will take care of this function in another pull request
2. This PR does not record who answered the survey like their name and when in firestore, I will take care of this function in another pull request
3. This PR does not send any email to users that they have successfully delete their account and their data as an evidence, I will take care of this function in another pull request

## References:


