### PR TITLE
Added "Connect with GitHub" button to use GitHub access token on behalf of users and viceversa

### DIFF
--- a/components/boxes/InputBox.tsx
+++ b/components/boxes/InputBox.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 
 interface InputBoxType {
+  bgColor?: string;
+  disabled?: boolean;
   inputType?: string;
   label?: string;
   max?: number;
@@ -13,6 +15,8 @@ interface InputBoxType {
 }
 
 const InputBox = ({
+  bgColor = 'bg-white',
+  disabled = false,
   inputType = 'text',
   label = 'a label here',
   max,
@@ -41,9 +45,10 @@ const InputBox = ({
           max={max}
           min={min}
           name={name}
-          className={`bg-white text-gray-700 border border-gray-300 rounded-lg block w-${width} dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 px-2 py-1 pl-3 mt-1`}
+          className={`${bgColor} text-gray-700 border border-gray-300 rounded-lg block w-${width} dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 px-2 py-1 pl-3 mt-1`}
           placeholder={placeholder} // Placeholder is NOT recommended, see https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/number#placeholder
           value={inputValue}
+          disabled={disabled}
           onChange={(e) => handleInputOnChange(e)}
         />
       </div>

--- a/components/buttons/ConnectWithGithub.tsx
+++ b/components/buttons/ConnectWithGithub.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { requestGithubUserIdentity } from '../../services/githubServices.client';
+
+interface PropTypes {
+  label?: string;
+}
+
+const ConnectWithGithubButton = ({ label = 'Submit' }: PropTypes) => {
+  return (
+    <button
+      className='w-auto h-7 bg-green-600 hover:bg-green-700 text-white font-semibold px-3 ml-3 mt-9 rounded-lg inline-block align-middle'
+      onClick={requestGithubUserIdentity}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default ConnectWithGithubButton;

--- a/components/buttons/DisconnectWithGithubButton.tsx
+++ b/components/buttons/DisconnectWithGithubButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { handleSubmitGithubAccessToken } from '../../services/setDocToFirestore';
+
+interface PropTypes {
+  label?: string;
+  uid: string;
+}
+
+const DisconnectWithGithubButton = ({ label = 'Submit', uid }: PropTypes) => {
+  const clientId = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID;
+  const url = `https://github.com/settings/connections/applications/${clientId}`;
+  return (
+    <button
+      className='w-auto h-7 bg-red-600 hover:bg-red-700 text-white font-semibold px-3 ml-3 mt-9 rounded-lg inline-block align-middle'
+      onClick={() => {
+        handleSubmitGithubAccessToken(uid, '');
+        window.open(url, '_blank');
+      }}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default DisconnectWithGithubButton;

--- a/components/buttons/SubmitButton.tsx
+++ b/components/buttons/SubmitButton.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
-const SubmitButton = () => {
+interface PropTypes {
+  label?: string;
+}
+
+const SubmitButton = ({ label = 'Submit' }: PropTypes) => {
   return (
     <button
       type='submit'
-      className='w-auto h-8 bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 mt-9 rounded-lg'
+      className='w-auto h-8 bg-gray-800 text-blue-100 hover:bg-gray-700 hover:text-white font-semibold py-1 px-3 mt-9 rounded-lg'
     >
-      Submit
+      {label}
     </button>
   );
 };

--- a/components/cards/NumberOfCommits.tsx
+++ b/components/cards/NumberOfCommits.tsx
@@ -1,7 +1,16 @@
 import { useNumberOfCommits } from '../../services/githubServices.client';
 
-// @ts-ignore
-const NumberOfCommits = ({ githubOwnerName, githubRepoName, githubUserId }) => {
+interface PropTypes {
+  githubOwnerName: string;
+  githubRepoName: string;
+  githubUserId: number;
+}
+
+const NumberOfCommits = ({
+  githubOwnerName,
+  githubRepoName,
+  githubUserId
+}: PropTypes) => {
   const data = useNumberOfCommits(
     githubOwnerName,
     githubRepoName,
@@ -32,7 +41,9 @@ const NumberOfCommits = ({ githubOwnerName, githubRepoName, githubUserId }) => {
         </div>
         <div>
           <div className='text-gray-400'># of commits</div>
-          <div className=' text-2xl font-bold text-gray-900'>{data} times</div>
+          <div className='text-2xl font-bold text-gray-900 text-left'>
+            {data} times
+          </div>
         </div>
       </div>
     </div>

--- a/components/common/Logout.tsx
+++ b/components/common/Logout.tsx
@@ -17,7 +17,7 @@ const LogOut = () => {
   return (
     <button
       type='button' // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
-      className='w-20 h-8 bg-gray-700 hover:bg-gray-600 text-blue-100 hover:text-white font-bold rounded-md absolute top-3.5 right-5'
+      className='w-20 h-8 bg-gray-800 hover:bg-gray-700 text-blue-100 hover:text-white font-semibold rounded-md absolute top-3.5 right-5'
       onClick={() => {
         handleClick();
       }}

--- a/config/firebaseTypes.ts
+++ b/config/firebaseTypes.ts
@@ -35,8 +35,9 @@ interface UserType extends Record<string, any> {
         visibility: string;
       }
     ];
-    userId: number;
-    userName: string;
+    userId?: number;
+    userName?: string;
+    accessToken?: string;
   };
   documentId?: string;
   lastName?: string;

--- a/pages/api/get-github-access-token.ts
+++ b/pages/api/get-github-access-token.ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type ResponseData = {
+  access_token: string;
+  scope: string;
+  token_type: string;
+};
+
+// Exchange a code for an GitHub access token
+// See https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
+const GetGithubAccessToken = async (
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) => {
+  const body = {
+    client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID,
+    client_secret: process.env.NEXT_PUBLIC_GITHUB_CLIENT_SECRET,
+    code: req.body.code
+    // redirectUri: process.env.NEXT_PUBLIC_GITHUB_REDIRECT_URI
+  };
+  const url = 'https://github.com/login/oauth/access_token';
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+    .then((res) => res.json())
+    .catch((err) => {
+      console.log({ err });
+      return err;
+    });
+
+  // This API responses with a JSON object containing the access token
+  res.status(200).json(response);
+};
+
+export default GetGithubAccessToken;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import nookies from 'nookies';
 
 // Config
 import { verifyIdToken } from '../firebaseAdmin';
+import { UserType } from '../config/firebaseTypes';
 
 // Components
 import ProfileList from '../components/common/ProfileList';
@@ -23,59 +24,41 @@ import {
 } from '../services/slackServices.server';
 import getAUserDoc from '../services/getAUserDocFromFirebase';
 
-export default function Home({
-  // @ts-ignore
-  numberOfMentioned,
-  // @ts-ignore
-  numberOfNewSent,
-  // @ts-ignore
-  numberOfReplies,
-  // @ts-ignore
-  asanaWorkspaceId,
-  // @ts-ignore
-  asanaUserId,
-  // @ts-ignore
-  asanaPersonalAccessToken,
-  // @ts-ignore
-  githubOwnerName,
-  // @ts-ignore
-  githubRepoName,
-  // @ts-ignore
-  githubUserId,
-  // @ts-ignore
-  githubUserName,
-  // @ts-ignore
-  profileList,
-  // @ts-ignore
-  uid
-}) {
-  // const { currentUser } = useAuth();
-  // const [open, setOpen] = useState(false);
-  // const [alertType, setAlertType] = useState("success");
-  // const [alertMessage, setAlertMessage] = useState("");
-  // const showAlert = (type, msg) => {
-  //   setAlertType(type);
-  //   setAlertMessage(msg);
-  //   setOpen(true);
-  // };
-  // const handleClose = (event, reason) => {
-  //   if (reason === "clickaway") {
-  //     return;
-  //   }
-  //   setOpen(false);
-  // };
-  // console.log('userDoc is: ', userDoc);
+interface PropTypes {
+  numberOfMentioned: number;
+  numberOfNewSent: number;
+  numberOfReplies: number;
+  asanaWorkspaceId: string;
+  asanaUserId: string;
+  asanaPersonalAccessToken: string;
+  githubOwnerName: string;
+  githubRepoName: string;
+  githubUserId: number;
+  githubUserName: string;
+  profileList: UserType;
+  uid: string;
+}
 
+export default function Home({
+  numberOfMentioned,
+  numberOfNewSent,
+  numberOfReplies,
+  asanaWorkspaceId,
+  asanaUserId,
+  asanaPersonalAccessToken,
+  githubOwnerName,
+  githubRepoName,
+  githubUserId,
+  githubUserName,
+  profileList,
+  uid
+}: PropTypes) {
   return (
     <>
       <Head>
         <title>Dashboard - WorkStats</title>
         <meta name='description' content='WorkStats' />
         <link rel='icon' href='/favicon.ico' />
-        {/* <link
-          rel="stylesheet"
-          href="https://unpkg.com/@themesberg/flowbite@1.3.3/dist/flowbite.min.css"
-        /> */}
       </Head>
       {profileList && (
         <main className='flex'>
@@ -100,10 +83,6 @@ export default function Home({
             />
             <div className='h-10'></div>
           </div>
-          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-          {/* <script src="https://unpkg.com/@themesberg/flowbite@1.3.3/dist/flowbite.bundle.js" /> */}
-          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
-          {/* <script src="https://unpkg.com/@themesberg/flowbite@1.3.3/dist/datepicker.bundle.js" /> */}
         </main>
       )}
     </>

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.517Z</lastmod></url>
-<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
-<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
-<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
-<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
-<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-23T07:32:34.518Z</lastmod></url>
+<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
 </urlset>

--- a/services/githubServices.client.tsx
+++ b/services/githubServices.client.tsx
@@ -9,6 +9,40 @@ const options = {
   revalidateOnReconnect: false
 };
 
+// Request a user's GitHub identity
+// THe official document is here https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity
+const requestGithubUserIdentity = () => {
+  const scopes =
+    'repo:status repo_deployment read:org read:user user:email read:discussion';
+  const unguessableRandomString = (outputLength: number) => {
+    const stringPool =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    return Array.from({ length: outputLength }, () =>
+      stringPool.charAt(Math.floor(Math.random() * stringPool.length))
+    ).join('');
+  };
+  interface PramsTypes {
+    client_id: string;
+    // redirect_uri: string;
+    scope: string;
+    state: string;
+    allow_signup: string;
+    [key: string]: string; // To avoid type error ts(7053) in params[key]
+  }
+  const params: PramsTypes = {
+    client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID || '',
+    // redirect_uri: 'https://auth.workstats.dev/__/auth/handler',
+    scope: scopes,
+    state: unguessableRandomString(16),
+    allow_signup: 'false'
+  };
+  const queryString = Object.keys(params)
+    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
+    .join('&');
+  const url = `https://github.com/login/oauth/authorize?${queryString}`;
+  window.location.href = url;
+};
+
 // Get a number of commits for a specific user
 // The official document is here https://docs.github.com/en/rest/reference/metrics#get-all-contributor-commit-activity
 const useNumberOfCommits = (
@@ -145,4 +179,9 @@ const useNumberOfReviews = (
   }
 };
 
-export { useNumberOfCommits, useNumberOfPullRequests, useNumberOfReviews };
+export {
+  useNumberOfCommits,
+  useNumberOfPullRequests,
+  useNumberOfReviews,
+  requestGithubUserIdentity
+};

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -34,13 +34,28 @@ const handleSubmitBasicInfo = async (
   return;
 };
 
+const handleSubmitGithubAccessToken = async (
+  docId: string,
+  githubAccessToken: string
+) => {
+  const docRef = doc(db, 'users', docId);
+  const docData = {
+    github: {
+      accessToken: githubAccessToken
+    }
+  };
+  const option = { merge: true };
+  await setDoc(docRef, docData, option);
+  return;
+};
+
 const handleSubmitSourceCode = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
 ) => {
   event.preventDefault();
   const docRef = doc(db, 'users', docId);
-  const docData = {
+  const docData: UserType = {
     github: {
       repositories: [
         {
@@ -71,7 +86,7 @@ const handleSubmitTaskTicket = async (
 ) => {
   event.preventDefault();
   const docRef = doc(db, 'users', docId);
-  const docData = {
+  const docData: UserType = {
     asana: {
       userId: event.currentTarget.asanaUserId.value,
       workspace: [
@@ -103,7 +118,7 @@ const handleSubmitCommunicationActivity = async (
 ) => {
   event.preventDefault();
   const docRef = doc(db, 'users', docId);
-  const docData = {
+  const docData: UserType = {
     slack: {
       workspace: [
         {
@@ -156,6 +171,7 @@ const handleSubmitSurveyWhyYouLeave = async (
 export {
   createUserDoc,
   handleSubmitBasicInfo,
+  handleSubmitGithubAccessToken,
   handleSubmitSourceCode,
   handleSubmitTaskTicket,
   handleSubmitCommunicationActivity,


### PR DESCRIPTION
## Problem:

OAuth for GitHub was not implemented. Therefore, use of the GitHub API was limited to public repositories, and the frequency of use was also limited.

## Solution:

A "Connect with GitHub" button has been added to the user settings screen. A "Disconnect with GitHub" button was also added to allow users to disconnect from GitHub after connecting with it.

## Evidence:

Follow the user operation procedures and put up evidence photos.

1. Open the User Settings page and press the "Connect with GitHub" button. 

![image](https://user-images.githubusercontent.com/4620828/170972532-7dce7dae-9173-45a4-884a-1c69e00be6e3.png)

2. A GitHub sign-in page will open OR an agreement screen will appear asking if you agree to grant these permissions to WorkStats on behalf of the signed-in GitHub user. Agree with this.

![image](https://user-images.githubusercontent.com/4620828/170973148-b0aca67d-c3f7-4640-8c0f-9debc5187f85.png)

3. You will be redirected to the user settings page. At this time, the "Connect with GitHub" button will automatically switch to the "Disconnect with GitHub" button.

![image](https://user-images.githubusercontent.com/4620828/170973394-12871b54-fb09-4e0c-81ec-3ebd4408b075.png)

4. The access token given by GitHub is stored in the user table.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/170973881-2dc523c7-556d-4a9a-a6da-e6169c423d18.png">

5. If the user reloads the page then the user can see it from this screen.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/170996592-3bac864b-43de-485c-842f-8ecc53fe925c.png">

6. If the user wants to stop granting permissions to WorkStats, press the "Disconnect with GitHub" button. When pressed, the user will be redirected to the OAuth app settings page in GitHub in a separate tab.

![image](https://user-images.githubusercontent.com/4620828/171003592-771fa7a1-871e-4c16-b0fc-29a7fe7ef099.png)

7. Within GitHub's external app settings page, revoke WorkStats authorization.

![image](https://user-images.githubusercontent.com/4620828/171003661-bbfe3e97-971c-4ab6-bdbf-637bcb9a8dab.png)
![image](https://user-images.githubusercontent.com/4620828/171003777-892f454a-5c5a-4ad4-84b4-0ba5d4a8380b.png)

8. Return to the user settings screen again and reload. The "Disconnect with GitHub" button will then be replaced with a "Connect with GitHub" button.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/171004103-77f44fda-970c-4989-9c89-5e2ecf5ed73f.png">

## Caveats:

We just created a button to get an access token, so it is not possible to aggregate the numbers in the private repository. That will be addressed in another pull request.

## References:

https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps
