### PR TITLE
Enabled GitHub APIs to access private repositories

### DIFF
--- a/components/cards/CardList.tsx
+++ b/components/cards/CardList.tsx
@@ -18,29 +18,34 @@ import NumberOfReviews from './NumberOfReview';
 // import GoogleAuthButton from './Auth&SignInButton';
 import GearIconLink from '../common/GearIcon';
 
+interface PropTypes {
+  numberOfMentioned: number;
+  numberOfNewSent: number;
+  numberOfReplies: number;
+  asanaWorkspaceId: string;
+  asanaUserId: string;
+  asanaPersonalAccessToken: string;
+  githubOwnerName: string;
+  githubRepoName: string;
+  githubUserId: number;
+  githubUserName: string;
+  githubAccessToken: string;
+}
+
 // @ts-ignore
 const CardList = ({
-  // @ts-ignore
   numberOfMentioned,
-  // @ts-ignore
   numberOfNewSent,
-  // @ts-ignore
   numberOfReplies,
-  // @ts-ignore
   asanaWorkspaceId,
-  // @ts-ignore
   asanaUserId,
-  // @ts-ignore
   asanaPersonalAccessToken,
-  // @ts-ignore
   githubOwnerName,
-  // @ts-ignore
   githubRepoName,
-  // @ts-ignore
   githubUserId,
-  // @ts-ignore
-  githubUserName
-}) => {
+  githubUserName,
+  githubAccessToken
+}: PropTypes) => {
   // const numberOfMeetings = 0;
 
   return (
@@ -75,16 +80,19 @@ const CardList = ({
             githubOwnerName={githubOwnerName}
             githubRepoName={githubRepoName}
             githubUserId={githubUserId}
+            githubAccessToken={githubAccessToken}
           />
           <NumberOfPullRequests
             githubOwnerName={githubOwnerName}
             githubRepoName={githubRepoName}
             githubUserId={githubUserId}
+            githubAccessToken={githubAccessToken}
           />
           <NumberOfReviews
             githubOwnerName={githubOwnerName}
             githubRepoName={githubRepoName}
             githubUserName={githubUserName}
+            githubAccessToken={githubAccessToken}
           />
         </div>
         <div className='flex'>

--- a/components/cards/NumberOfCommits.tsx
+++ b/components/cards/NumberOfCommits.tsx
@@ -4,17 +4,20 @@ interface PropTypes {
   githubOwnerName: string;
   githubRepoName: string;
   githubUserId: number;
+  githubAccessToken: string;
 }
 
 const NumberOfCommits = ({
   githubOwnerName,
   githubRepoName,
-  githubUserId
+  githubUserId,
+  githubAccessToken
 }: PropTypes) => {
   const data = useNumberOfCommits(
     githubOwnerName,
     githubRepoName,
-    githubUserId
+    githubUserId,
+    githubAccessToken
   );
 
   return (

--- a/components/cards/NumberOfPullRequests.tsx
+++ b/components/cards/NumberOfPullRequests.tsx
@@ -1,17 +1,23 @@
 import { useNumberOfPullRequests } from '../../services/githubServices.client';
 
+interface PropTypes {
+  githubOwnerName: string;
+  githubRepoName: string;
+  githubUserId: number;
+  githubAccessToken: string;
+}
+
 const NumberOfPullRequests = ({
-  // @ts-ignore
   githubOwnerName,
-  // @ts-ignore
   githubRepoName,
-  // @ts-ignore
-  githubUserId
-}) => {
+  githubUserId,
+  githubAccessToken
+}: PropTypes) => {
   const data = useNumberOfPullRequests(
     githubOwnerName,
     githubRepoName,
-    githubUserId
+    githubUserId,
+    githubAccessToken
   );
   return (
     <div className='bg-white shadow rounded-lg p-4 hover:bg-slate-200'>

--- a/components/cards/NumberOfReview.tsx
+++ b/components/cards/NumberOfReview.tsx
@@ -1,17 +1,23 @@
 import { useNumberOfReviews } from '../../services/githubServices.client';
 
+interface PropTypes {
+  githubOwnerName: string;
+  githubRepoName: string;
+  githubUserName: string;
+  githubAccessToken: string;
+}
+
 const NumberOfReviews = ({
-  // @ts-ignore
   githubOwnerName,
-  // @ts-ignore
   githubRepoName,
-  // @ts-ignore
-  githubUserName
-}) => {
+  githubUserName,
+  githubAccessToken
+}: PropTypes) => {
   const data = useNumberOfReviews(
     githubOwnerName,
     githubRepoName,
-    githubUserName
+    githubUserName,
+    githubAccessToken
   );
   // console.log(`data is: ${data}`);
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,6 +35,7 @@ interface PropTypes {
   githubRepoName: string;
   githubUserId: number;
   githubUserName: string;
+  githubAccessToken: string;
   profileList: UserType;
   uid: string;
 }
@@ -50,6 +51,7 @@ export default function Home({
   githubRepoName,
   githubUserId,
   githubUserName,
+  githubAccessToken,
   profileList,
   uid
 }: PropTypes) {
@@ -80,6 +82,7 @@ export default function Home({
               githubRepoName={githubRepoName}
               githubUserId={githubUserId}
               githubUserName={githubUserName}
+              githubAccessToken={githubAccessToken}
             />
             <div className='h-10'></div>
           </div>
@@ -137,6 +140,9 @@ export const getServerSideProps: GetServerSideProps = async (
     const githubUserId = userDoc?.github?.userId ? userDoc.github.userId : null;
     const githubUserName = userDoc?.github?.userName
       ? userDoc.github.userName
+      : null;
+    const githubAccessToken = userDoc?.github?.accessToken
+      ? userDoc.github.accessToken
       : null;
 
     // Parameters for slack
@@ -218,6 +224,7 @@ export const getServerSideProps: GetServerSideProps = async (
         githubOwnerName,
         githubUserId,
         githubUserName,
+        githubAccessToken,
         profileList,
         uid
       }

--- a/pages/user-settings.tsx
+++ b/pages/user-settings.tsx
@@ -47,7 +47,6 @@ const useUserSettings = ({
     isGithubAuthenticated
   );
   const [githubAccessToken, setGithubAccessToken] = useState('');
-  console.log({ isGithubAuthenticatedState, githubAccessToken });
   useEffect(() => {
     if (code && !isGithubAuthenticatedState) {
       const url = '/api/get-github-access-token';

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
-<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-30T09:55:58.704Z</lastmod></url>
+<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
+<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-05-31T09:16:37.832Z</lastmod></url>
 </urlset>

--- a/services/githubServices.client.tsx
+++ b/services/githubServices.client.tsx
@@ -12,8 +12,7 @@ const options = {
 // Request a user's GitHub identity
 // THe official document is here https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity
 const requestGithubUserIdentity = () => {
-  const scopes =
-    'repo:status repo_deployment read:org read:user user:email read:discussion';
+  const scopes = 'repo read:org user read:discussion';
   const unguessableRandomString = (outputLength: number) => {
     const stringPool =
       'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -48,7 +47,8 @@ const requestGithubUserIdentity = () => {
 const useNumberOfCommits = (
   owner: string,
   repo: string,
-  githubUserId: number
+  githubUserId: number,
+  accessToken?: string
 ) => {
   // console.log(`githubUserId is: ${githubUserId}`);
   const url = `${base}/repos/${owner}/${repo}/stats/contributors`;
@@ -57,6 +57,9 @@ const useNumberOfCommits = (
   }
   const headers = new Headers();
   headers.append('Accept', 'application/vnd.github.v3+json');
+  accessToken && accessToken !== ''
+    ? headers.append('Authorization', `token ${accessToken}`)
+    : null;
   const fetcher = async (url: string) => {
     const response = await fetch(url, {
       headers: headers
@@ -87,7 +90,8 @@ const useNumberOfCommits = (
 const useNumberOfPullRequests = (
   owner: string,
   repo: string,
-  githubUserId: number
+  githubUserId: number,
+  accessToken?: string
 ) => {
   const params = {
     state: 'closed', // or "open", "all"
@@ -104,6 +108,9 @@ const useNumberOfPullRequests = (
   // The official document is here: https://swr.vercel.app/docs/data-fetching
   const headers = new Headers();
   headers.append('Accept', 'application/vnd.github.v3+json');
+  accessToken && accessToken !== ''
+    ? headers.append('Authorization', `token ${accessToken}`)
+    : null;
   const fetcher = async (url: string) => {
     let count = 0;
     let totalCount = 0;
@@ -146,7 +153,8 @@ const useNumberOfPullRequests = (
 const useNumberOfReviews = (
   owner: string,
   repo: string,
-  githubUserName: string
+  githubUserName: string,
+  accessToken?: string
 ): number => {
   const params = {
     q: `is:pr repo:${owner}/${repo} reviewed-by:${githubUserName}`,
@@ -159,6 +167,9 @@ const useNumberOfReviews = (
 
   const headers = new Headers();
   headers.append('Accept', 'application/vnd.github.v3+json');
+  accessToken && accessToken !== ''
+    ? headers.append('Authorization', `token ${accessToken}`)
+    : null;
   const fetcher = async (url: string) => {
     const response = await fetch(url, {
       headers: headers


### PR DESCRIPTION
## Problem:

Previously, there was no authentication, so only information from public repositories could be obtained. This limited the number of target users.

## Solution:

A process was created in the previous pull request for a user to perform OAuth authentication and grant specific permissions to WorkStats. The access token obtained there was added to the three API headers on GitHub. This has made it possible to retrieve information on private repositories and, although unconfirmed, has probably greatly improved the maximum number of times the API can be used.

## Evidence:

A repository I had previously created as a sample was used for testing. It is in a private state.

<img width="972" alt="image" src="https://user-images.githubusercontent.com/4620828/171141421-321a8f8d-ed94-4f76-9640-f2d822a217f4.png">

In user settings, configure this private repository in repository 1.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/171141663-dc589684-0029-4d3f-a37a-8c0967490186.png">

Numbers in private repositories are aggregated.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/171141214-3c2f9d29-cce4-47b5-8fd9-ff95ea35d0e6.png">

## Caveats:

Nothing

## References:

How to use Access Token;
https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#3-use-the-access-token-to-access-the-api

What are Scopes;
https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps
