### PR TITLE
Hotfix: Fixed a bug that sometimes prevented user documents from being created.

### DIFF
--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -35,6 +35,8 @@ const Login = () => {
         // This gives you a Google Access Token. You can use it to access the Google API.
         const user = result.user;
         createUserDoc(user.uid);
+      })
+      .then(() => {
         window.location.reload();
       })
       .catch((error) => {
@@ -60,6 +62,8 @@ const Login = () => {
       .then((result) => {
         const user = result.user;
         createUserDoc(user.uid);
+      })
+      .then(() => {
         window.location.reload();
       })
       .catch((error) => {


### PR DESCRIPTION
## Problem:

As the title suggests, sometimes there are cases where user documentation is not created. The reproducible conditions are difficult to figure out.

## Solution:

The only place to create user documentation is in the login component, so that is the only possible cause. After looking at the source, I guessed that this phenomenon might occur when the reload in the next line finishes first, without waiting for the Promise that the user document creation is completed.

## Evidence:

Nothing special

## Caveats:

Nothing special

## References:

Nothing special
