### PR TITLE
Reduced size of environment variables which is not secrets

### DIFF
--- a/config/firebaseClient.js
+++ b/config/firebaseClient.js
@@ -5,9 +5,9 @@ import { getAuth, GithubAuthProvider, GoogleAuthProvider } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  authDomain: 'polygonhr-d5153.firebaseapp.com',
+  projectId: 'polygonhr-d5153',
+  storageBucket: 'polygonhr-d5153.appspot.com',
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID

--- a/firebaseAdmin.ts
+++ b/firebaseAdmin.ts
@@ -1,17 +1,17 @@
 const admin = require('firebase-admin');
 const serviceAccount = {
-  type: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_TYPE,
-  project_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PROJECT_ID,
+  type: 'service_account',
+  project_id: 'polygonhr-d5153',
   private_key_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY_ID,
   private_key: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY
     ? process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY.replace(/\\n/g, '\n')
     : undefined,
-  client_email: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_EMAIL,
+  client_email:
+    'firebase-adminsdk-y10m7@polygonhr-d5153.iam.gserviceaccount.com',
   client_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_ID,
-  auth_uri: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_AUTH_URI,
-  token_uri: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_TOKEN_URI,
-  auth_provider_x509_cert_url:
-    process.env.NEXT_PUBLIC_FIREBASE_ADMIN_AUTH_PROVIDER_X509_CERT_URL,
+  auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+  token_uri: 'https://oauth2.googleapis.com/token',
+  auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
   client_x509_cert_url:
     process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_X509_CERT_URL
 };


### PR DESCRIPTION
## Problem:

The upper limit on the size of environment variables that can be registered in the console with Vercel Hosting is 4kb, but it was just barely enough. If it exceeds the limit, we will not be able to deploy.

## Solution:

The solution itself is provided by Vercel in two ways: one is to Encrypt and Decrypt, which I have read carefully and the implementation itself is not that complicated, but it is more complicated to operate and manage. For example, if we encrypt environment variables related to Firebase, specifically if we later want to change the Auth Domain to the correct name, we have to encrypt it again. That is a special procedure that I would prefer not to do.

Therefore, I decided to write the environment variables directly in the source code, which would not cause much of a problem even if they were leaked. This has the advantage of being simple and easy to review.

## Evidence:

Nothing changed

![image](https://user-images.githubusercontent.com/4620828/173106711-78890449-513e-4d53-b9e5-1a0e09a73862.png)

![image](https://user-images.githubusercontent.com/4620828/173106772-e8e4075a-a629-40a5-a686-f64314300ffa.png)

## Caveats:



## References:

https://vercel.com/docs/concepts/limits/overview#environment-variables
https://vercel.com/support/articles/how-do-i-workaround-vercel-s-4-kb-environment-variables-limit