### PR TITLE
Added a card to show estimated completion date for Asana

### DIFF
--- a/components/cards/CardList.tsx
+++ b/components/cards/CardList.tsx
@@ -19,6 +19,7 @@ import VelocityOfTaskClose from './VelocityOfTaskClose';
 // import GoogleAuthButton from './Auth&SignInButton';
 import GearIconLink from '../common/GearIcon';
 import { useNumberOfTasks } from '../../services/asanaServices.client';
+import EstimatedDateOfCompletion from './EstimatedDateOfTaskEnd';
 
 interface PropTypes {
   numberOfMentioned: number;
@@ -88,7 +89,7 @@ const CardList = ({
             alt='Gear icon links to user settings'
           />
         </div>
-        <div className='grid gap-3 md:gap-6 grid-cols-2 lg:grid-cols-3'>
+        <div className='grid gap-3 md:gap-5 grid-cols-2 lg:grid-cols-3'>
           <NumberOfCommits
             githubOwnerName={githubOwnerName}
             githubRepoName={githubRepoName}
@@ -117,10 +118,13 @@ const CardList = ({
             alt='Gear icon links to user settings'
           />
         </div>
-        <div className='grid gap-3 md:gap-6 grid-cols-2 lg:grid-cols-3'>
+        <div className='grid gap-3 md:gap-5 grid-cols-2 lg:grid-cols-3'>
           <NumberOfCloseTasks number={numberOfTasks.numberOfClosed} />
           <NumberOfOpenTasks number={numberOfTasks.numberOfOpened} />
           <VelocityOfTaskClose number={numberOfTasks.velocityPerWeeks} />
+          <EstimatedDateOfCompletion
+            date={numberOfTasks.estimatedCompletionDate}
+          />
         </div>
         <div className='flex'>
           <h2 className='text-xl mt-4 mb-2'>Communication - Slack</h2>
@@ -131,7 +135,7 @@ const CardList = ({
             alt='Gear icon links to user settings'
           />
         </div>
-        <div className='grid gap-3 md:gap-6 grid-cols-2 lg:grid-cols-3'>
+        <div className='grid gap-3 md:gap-5 grid-cols-2 lg:grid-cols-3'>
           <NumberOfMentioned data={numberOfMentioned} />
           <NumberOfReplies data={numberOfReplies} />
           <NumberOfNewSent data={numberOfNewSent} />

--- a/components/cards/EstimatedDateOfTaskEnd.tsx
+++ b/components/cards/EstimatedDateOfTaskEnd.tsx
@@ -1,0 +1,47 @@
+interface PropTypes {
+  date: string;
+}
+
+const EstimatedDateOfCompletion = ({ date }: PropTypes) => {
+  return (
+    <div className='bg-white shadow rounded-lg p-3 md:p-4 hover:bg-slate-200'>
+      <div className='flex space-x-4 items-center'>
+        <div>
+          <div className='bg-purple-50 rounded-full w-5 h-5 md:w-12 md:h-12 text-purple-400 flex justify-center items-center'>
+            <svg
+              width='32px'
+              height='32px'
+              viewBox='0 0 48 48'
+              fill='none'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <rect width='48' height='48' fill='white' fillOpacity='0.01' />
+              <path
+                d='M43 11L16.875 37L5 25.1818'
+                stroke='currentColor'
+                strokeWidth='5'
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                fill='none'
+                color='currentColor'
+              />
+            </svg>
+          </div>
+        </div>
+        <div>
+          <div className='text-gray-400 text-sm md:text-base'>
+            Est. cmpl. date
+          </div>
+          <div className='hidden md:contents md:text-2xl md:font-bold md:text-gray-900'>
+            {date ? date : '--'}
+          </div>
+        </div>
+      </div>
+      <div className='md:hidden text-xl font-bold text-gray-900'>
+        {date ? date : '--'}
+      </div>
+    </div>
+  );
+};
+
+export default EstimatedDateOfCompletion;

--- a/components/cards/VelocityOfTaskClose.tsx
+++ b/components/cards/VelocityOfTaskClose.tsx
@@ -29,7 +29,7 @@ const VelocityOfTaskClose = ({ number }: PropTypes) => {
         </div>
         <div>
           <div className='text-gray-400 text-sm md:text-base'>
-            Vel. of cls tasks
+            Vel. of cls. tasks
           </div>
           <div className='hidden md:contents md:text-2xl md:font-bold md:text-gray-900'>
             {number ? number : 0} <span className='md:text-xl'>times/wk</span>

--- a/services/asanaServices.client.tsx
+++ b/services/asanaServices.client.tsx
@@ -143,6 +143,8 @@ const useNumberOfTasks = (
     const numberOfClosed: number = response['data']?.filter((item: item) => {
       return item['completed'] === true;
     })?.length;
+    const numberOfOpened: number =
+      numberOfAll - numberOfClosed ? numberOfAll - numberOfClosed : 0;
 
     // Get the earliest created_at date
     // See the MDN docs here, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
@@ -157,19 +159,28 @@ const useNumberOfTasks = (
       now // Initial value
     );
     const durationDays = moment(now).diff(earliestCreatedAt, 'days', true);
+    const velocityPerDays = Math.round(numberOfClosed / durationDays)
+      ? Math.round((numberOfClosed / durationDays) * 10) / 10
+      : 0; // Daily basis including Saturdays and Sundays
+    const remainingDevDays = Math.round(numberOfOpened / velocityPerDays)
+      ? Math.round(numberOfOpened / velocityPerDays)
+      : 0;
+    const estimatedCompletionDate = moment()
+      .add(remainingDevDays, 'days')
+      .format('MMM D YYYY');
 
     const output = {
       numberOfAll: numberOfAll,
       numberOfClosed: numberOfClosed ? numberOfClosed : 0,
-      numberOfOpened:
-        numberOfAll - numberOfClosed ? numberOfAll - numberOfClosed : 0,
+      numberOfOpened: numberOfOpened ? numberOfOpened : 0,
       durationDays: durationDays ? durationDays : 0,
       velocityPerDays: Math.round((numberOfClosed / durationDays) * 7)
         ? Math.round(((numberOfClosed / durationDays) * 70) / 5) / 10
-        : 0,
+        : 0, // weekday basis
       velocityPerWeeks: Math.round((numberOfClosed / durationDays) * 7)
         ? Math.round((numberOfClosed / durationDays) * 70) / 10
-        : 0
+        : 0,
+      estimatedCompletionDate: estimatedCompletionDate
     };
     return output;
   };
@@ -184,7 +195,8 @@ const useNumberOfTasks = (
     numberOfClosed: 0,
     numberOfOpened: 0,
     velocityPerDays: 0,
-    velocityPerWeeks: 0
+    velocityPerWeeks: 0,
+    estimatedCompletionDate: '--'
   };
 
   if (error) {


### PR DESCRIPTION
## Problem

Although the average weekly speed of task completion was available, users had to calculate by hand when all of their current tasks would be completed if they estimated at that speed. Users can calculate the approximate completion date in their minds, but if the date is clearly stated, they will have more time to think about whether the date is good or bad.

## Solution

Added a card to show the estimated completion date for Asana to solve the problem.

## Evidence

For mobile screen;

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/4620828/173511480-51ce9a52-ca16-4ebd-9074-eb9c82b55bdc.png)|![image](https://user-images.githubusercontent.com/4620828/173511069-6c353405-3bd7-410f-b882-e55310ebfb20.png)|

For desktop screen;

|Before|
|---|
|![image](https://user-images.githubusercontent.com/4620828/173511155-a5cb4af4-53e8-42d6-a79e-500c3aed7822.png)|

|After|
|---|
|![image](https://user-images.githubusercontent.com/4620828/173511217-1b3cfa4a-d2c9-4b91-8048-339372ff0c7b.png)|

### Environment Variables Setting

Do you require registration to the following console screens other than the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions:  No
- Vercel Hosting:  No
- Firebase Console:  No
- Google Cloud Platform:  No
- Asana Developer Console:  No
- Slack Developer Console:  No

## Caveats

No

## References

No
