### PR TITLE
Fixed an error in which if the first decimal place of a speed was 0, the 0 would be lost.

### DIFF
--- a/components/cards/CardList.tsx
+++ b/components/cards/CardList.tsx
@@ -121,7 +121,9 @@ const CardList = ({
         <div className='grid gap-3 md:gap-5 grid-cols-2 lg:grid-cols-3'>
           <NumberOfCloseTasks number={numberOfTasks.numberOfClosed} />
           <NumberOfOpenTasks number={numberOfTasks.numberOfOpened} />
-          <VelocityOfTaskClose number={numberOfTasks.velocityPerWeeks} />
+          <VelocityOfTaskClose
+            number={numberOfTasks.velocityPerWeeks.toFixed(1)} // If the first decimal place is 0, it is converted to a string to keep the 0
+          />
           <EstimatedDateOfCompletion
             date={numberOfTasks.estimatedCompletionDate}
           />

--- a/components/cards/VelocityOfTaskClose.tsx
+++ b/components/cards/VelocityOfTaskClose.tsx
@@ -1,5 +1,5 @@
 interface PropTypes {
-  number: number;
+  number: string;
 }
 
 const VelocityOfTaskClose = ({ number }: PropTypes) => {

--- a/services/asanaServices.client.tsx
+++ b/services/asanaServices.client.tsx
@@ -80,7 +80,7 @@ const refreshAccessToken = async (
     headers: headers,
     body: JSON.stringify(body)
   });
-  const output = response.json();
+  const output = await response.json();
   return output;
 };
 
@@ -119,11 +119,7 @@ const useNumberOfTasks = (
         if (res.status === 401 && asanaRefreshToken && uid) {
           refreshAccessToken(asanaRefreshToken)
             .then(async (res) => {
-              await handleSubmitAsanaAccessToken(
-                uid,
-                res.access_token,
-                res.data.gid
-              );
+              await handleSubmitAsanaAccessToken(uid, res.access_token);
               myHeaders.set('Authorization', 'Bearer ' + res.access_token);
             })
             .then(async () => {

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -83,7 +83,7 @@ const handleSubmitSourceCode = async (
 const handleSubmitAsanaAccessToken = async (
   docId: string,
   accessToken: string,
-  userId: string,
+  userId?: string,
   refreshToken?: string
 ) => {
   const docRef = doc(db, 'users', docId);
@@ -91,8 +91,7 @@ const handleSubmitAsanaAccessToken = async (
     !refreshToken && refreshToken !== ''
       ? {
           asana: {
-            accessToken: accessToken,
-            userId: userId
+            accessToken: accessToken
           }
         }
       : {


### PR DESCRIPTION
## Problem

There was an error where if the first decimal place in the average weekly speed of the number of tasks completed was 0, that 0 would disappear. I noticed that 8.0 happened to be 8, as shown in the screenshot. This may be confusing to you, but to the user, it is not visually obvious whether 8.4 was rounded to 8, 7.6 was rounded to 8, or 8.0 became 8!

While correcting the problem, we noticed other minor errors that needed to be addressed.

## Solution

The toFixed method was used to solve the problem.

## Evidence

For desktop screen;

|Before|
|---|
|![image](https://user-images.githubusercontent.com/4620828/173828302-15cf874c-fee9-46aa-9bb0-8bddbc4d7f69.png)|

|After|
|---|
|![image](https://user-images.githubusercontent.com/4620828/173828363-53daa20d-417e-4efe-98f6-5badc899e49c.png)|

### Environment Variables Setting

Do you require registration to the following console screens other than the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions:  No
- Vercel Hosting:  No
- Firebase Console:  No
- Google Cloud Platform:  No
- Asana Developer Console:  No
- Slack Developer Console:  No

## Caveats

No

## References

No
