### PR TITLE
Removed google sensitive scope from source code

### DIFF
--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -26,8 +26,8 @@ import ProductHunt from '../buttons/ProductHunt';
 import Head from 'next/head';
 
 // Scopes in detail: https://developers.google.com/identity/protocols/oauth2/scopes#calendar
-const scopes = 'https://www.googleapis.com/auth/calendar.readonly	';
-googleProvider.addScope(scopes);
+// const scopes = 'https://www.googleapis.com/auth/calendar.readonly	';
+// googleProvider.addScope(scopes);
 
 const Login = () => {
   // google login handler


### PR DESCRIPTION
## Problem

If you are using the Google OAuth provider provided by Firebase for login, the scope must match between the source code itself and the settings on the Google Cloud Platform console screen. If they did not match, an alert message "This app is not verified" would be generated by Google, which was a major cause of abandonment for new users. Once logged in, the alert message never appeared again for that account, so I assumed it was resolved and it took me a while to realize that it actually was not.

## Solution

Commented out the scope for Google Calendar that was in the source code.

## Evidence

For desktop screen;

### Before

As noted in the issue, an alert message appears before login, and if the user ignores it, a scope confirmation screen appears next.

|STEP1|STEP2|
|---|---|
|![image](https://user-images.githubusercontent.com/4620828/174474939-d5d8444a-36fe-4c87-ac13-06afd928632e.png)|![image](https://user-images.githubusercontent.com/4620828/174474979-839fcde6-c29a-42b1-98fe-efb22ab4a60f.png)|

|STEP3|STEP4|
|---|---|
|![image](https://user-images.githubusercontent.com/4620828/174475006-23b1fb3d-a554-4e09-a460-c5de249dead8.png)|![image](https://user-images.githubusercontent.com/4620828/174475038-1c2e49af-ed53-4965-a50b-adab73310f74.png)|

|STEP5||
|---|---|
|![image](https://user-images.githubusercontent.com/4620828/174475118-056d9c04-41e2-4de2-9f17-90e8c14e08a1.png)||

### After

You will be logged in as soon as you press the login button. You will not be asked for your scope, nor will you get an alert message.

|STEP1|STEP2|
|---|---|
|![image](https://user-images.githubusercontent.com/4620828/174474575-2929c35a-6da0-4838-9525-c7bba125cdf3.png)|![image](https://user-images.githubusercontent.com/4620828/174474837-cbb4e9cc-3398-4bfb-af69-4271c7aecfbf.png)|

### Environment Variables Setting

Do you require registration to the following console screens other than the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions: No
- Vercel Hosting: No
- Firebase Console: No
- Google Cloud Platform: No
- Asana Developer Console: No
- Slack Developer Console: No

## Caveats

This is only a temporary fix, and eventually we will be looking at Google Calendar data, so the app must be properly authenticated in a legitimate Google-designated manner.

## References

https://support.google.com/cloud/answer/7454865?hl=en
