### PR TITLE
Supported Slack OAuth 2.0

### DIFF
--- a/components/buttons/DisconnectWithSlack.tsx
+++ b/components/buttons/DisconnectWithSlack.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { handleSubmitSlackAccessToken } from '../../services/setDocToFirestore';
+
+interface PropTypes {
+  label: string;
+  uid: string;
+  accessToken: string | undefined;
+}
+
+const DisconnectWithSlackButton = ({ label, uid, accessToken }: PropTypes) => {
+  const url = '/api/revoke-slack-refresh-token';
+  const body = {
+    uid,
+    accessToken
+  };
+
+  return (
+    <button
+      className='w-auto h-7 bg-red-600 hover:bg-red-700 text-white font-semibold px-3 ml-3 mt-9 rounded-lg inline-block align-middle'
+      onClick={async () => {
+        await handleSubmitSlackAccessToken(uid, '', '', '');
+        // Deauthorize Asana
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(body)
+        });
+        if (response.status === 200) {
+          alert('Slack has been deauthorized');
+          window.location.replace(window.location.pathname);
+        }
+      }}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default DisconnectWithSlackButton;

--- a/config/firebaseTypes.ts
+++ b/config/firebaseTypes.ts
@@ -5,36 +5,24 @@ interface UserType extends Record<string, unknown> {
     userId?: string;
     accessToken?: string;
     refreshToken?: string;
-    workspace: [
-      {
-        workspaceId: string;
-        workspaceName: string;
-      },
-      {
-        workspaceId: string;
-        workspaceName: string;
-      }
-    ];
+    workspace?: Array<{
+      workspaceId?: string;
+      workspaceName?: string;
+    }>;
   };
   assessor?: string;
   assignedPj?: string;
   avatarUrl?: string;
   birth?: Timestamp | number; // DB has Timestamp type but birth could be converted to number
+  companyName?: string;
   department?: string;
   firstName?: string;
   github?: {
-    repositories: [
-      {
-        owner: string;
-        repo: string;
-        visibility: string;
-      },
-      {
-        owner: string;
-        repo: string;
-        visibility: string;
-      }
-    ];
+    repositories?: Array<{
+      owner?: string;
+      repo?: string;
+      visibility?: string;
+    }>;
     userId?: number;
     userName?: string;
     accessToken?: string;
@@ -45,20 +33,11 @@ interface UserType extends Record<string, unknown> {
   rank?: string;
   role?: string;
   slack?: {
-    workspace: [
-      {
-        botToken: string;
-        memberId: string;
-        userToken: string;
-        workspaceName: string;
-      },
-      {
-        botToken: string;
-        memberId: string;
-        userToken: string;
-        workspaceName: string;
-      }
-    ];
+    workspace?: Array<{
+      accessToken?: string;
+      memberId?: string;
+      workspaceName?: string;
+    }>;
   };
   supervisor?: string;
 }

--- a/firebaseAdmin.ts
+++ b/firebaseAdmin.ts
@@ -1,4 +1,6 @@
 const admin = require('firebase-admin');
+const firebaseAdminClientEmail =
+  process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_EMAIL || '';
 const serviceAccount = {
   type: 'service_account',
   project_id: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
@@ -6,13 +8,14 @@ const serviceAccount = {
   private_key: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY
     ? process.env.NEXT_PUBLIC_FIREBASE_ADMIN_PRIVATE_KEY.replace(/\\n/g, '\n')
     : undefined,
-  client_email: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_EMAIL,
+  client_email: firebaseAdminClientEmail,
   client_id: process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_ID,
   auth_uri: 'https://accounts.google.com/o/oauth2/auth',
   token_uri: 'https://oauth2.googleapis.com/token',
   auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
-  client_x509_cert_url:
-    process.env.NEXT_PUBLIC_FIREBASE_ADMIN_CLIENT_X509_CERT_URL
+  client_x509_cert_url: `https://www.googleapis.com/robot/v1/metadata/x509/${encodeURIComponent(
+    firebaseAdminClientEmail
+  )}`
 };
 
 // @ts-ignore

--- a/pages/api/get-asana-access-token.ts
+++ b/pages/api/get-asana-access-token.ts
@@ -34,7 +34,8 @@ const GetAsanaAccessToken = async (
     grant_type: req.body.grant_type,
     client_id: process.env.NEXT_PUBLIC_ASANA_CLIENT_ID || '',
     client_secret: process.env.ASANA_CLIENT_SECRET || '',
-    redirect_uri: process.env.NEXT_PUBLIC_ASANA_REDIRECT_URI || '',
+    redirect_uri:
+      `${process.env.NEXT_PUBLIC_ORIGIN}/user-settings?asana=true` || '',
     code: req.body.code,
     refresh_token: req.body.refresh_token || ''
   };

--- a/pages/api/get-asana-access-token.ts
+++ b/pages/api/get-asana-access-token.ts
@@ -24,7 +24,7 @@ interface bodyType {
   [key: string]: string; // To avoid type error ts(7053) in params[key]
 }
 
-// Exchange a code for an GitHub access token
+// Exchange a code for an Asana access token
 // See chapter 'Token Exchange Endpoint' in https://developers.asana.com/docs/oauth
 const GetAsanaAccessToken = async (
   req: NextApiRequest,

--- a/pages/api/get-slack-access-token.ts
+++ b/pages/api/get-slack-access-token.ts
@@ -49,7 +49,8 @@ const GetSlackAccessToken = async (
     client_secret: process.env.SLACK_CLIENT_SECRET || '',
     code: req.body.code,
     grant_type: req.body.grant_type,
-    redirect_uri: process.env.NEXT_PUBLIC_SLACK_REDIRECT_URI || ''
+    redirect_uri:
+      `${process.env.NEXT_PUBLIC_ORIGIN}/user-settings?slack=true` || ''
     // refresh_token: req.body.refresh_token || ''
   };
   const bodyString = Object.keys(body)

--- a/pages/api/get-slack-access-token.ts
+++ b/pages/api/get-slack-access-token.ts
@@ -1,0 +1,75 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type ResponseData = {
+  ok: boolean;
+  access_token?: string; // for bots
+  token_type?: string;
+  scope?: string;
+  bot_user_id?: string;
+  app_id?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  team: {
+    name?: string;
+    id: string;
+  };
+  enterprise: null | {
+    name: string;
+    id: string;
+  };
+  is_enterprise_install?: boolean;
+  authed_user: {
+    id: string;
+    scope: string;
+    access_token: string;
+    expires_in?: number;
+    refresh_token?: string;
+    token_type: string;
+  };
+};
+
+interface bodyType {
+  client_id: string;
+  client_secret: string;
+  code: string;
+  grant_type: 'authorization_code' | 'refresh_token';
+  redirect_uri: string;
+  // refresh_token: string;
+  [key: string]: string; // To avoid type error ts(7053) in params[key]
+}
+
+// Exchange a code for an Slack access token
+// See https://api.slack.com/methods/oauth.v2.access
+const GetSlackAccessToken = async (
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) => {
+  const body: bodyType = {
+    client_id: process.env.NEXT_PUBLIC_SLACK_CLIENT_ID || '',
+    client_secret: process.env.SLACK_CLIENT_SECRET || '',
+    code: req.body.code,
+    grant_type: req.body.grant_type,
+    redirect_uri: process.env.NEXT_PUBLIC_SLACK_REDIRECT_URI || ''
+    // refresh_token: req.body.refresh_token || ''
+  };
+  const bodyString = Object.keys(body)
+    .map((key) => `${key}=${encodeURIComponent(body[key])}`)
+    .join('&');
+  const url = 'https://slack.com/api/oauth.v2.access';
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: bodyString
+  })
+    .then((res) => res.json())
+    .catch((err) => {
+      console.log({ err });
+      return err;
+    });
+
+  res.status(200).json(response);
+};
+
+export default GetSlackAccessToken;

--- a/pages/api/revoke-asana-refresh-token.ts
+++ b/pages/api/revoke-asana-refresh-token.ts
@@ -11,7 +11,7 @@ interface bodyType {
   [key: string]: string; // To avoid type error ts(7053) in params[key]
 }
 
-// Exchange a code for an GitHub access token
+// Revoke an Asana refresh token
 // See 'Token Deauthorization Endpoint' chapter in https://developers.asana.com/docs/oauth
 const RevokeAsanaRefreshToken = async (
   req: NextApiRequest,

--- a/pages/api/revoke-slack-refresh-token.ts
+++ b/pages/api/revoke-slack-refresh-token.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type ResponseType = {
+  status: number;
+};
+
+interface OriginalResponseType {
+  ok: boolean;
+  error?: string;
+  revoked: boolean;
+}
+
+interface bodyType {
+  token: string; // Slack access token
+  // test: boolean;
+  [key: string]: string; // To avoid type error ts(7053) in params[key]
+}
+
+// Revoke an Slack access token
+// See here https://api.slack.com/methods/auth.revoke
+const RevokeSlackRefreshToken = async (
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseType>
+) => {
+  const body: bodyType = {
+    token: req.body.accessToken
+  };
+  const bodyString = Object.keys(body)
+    .map((key) => `${key}=${encodeURIComponent(body[key])}`)
+    .join('&');
+  const url = 'https://slack.com/api/auth.revoke';
+  const response: OriginalResponseType = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: bodyString
+  })
+    .then((res) => res.json())
+    .catch((err) => {
+      console.log({ err });
+      return err;
+    });
+
+  res.status(200).json({ status: response.revoked ? 200 : 400 });
+};
+
+export default RevokeSlackRefreshToken;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -155,7 +155,7 @@ export const getServerSideProps: GetServerSideProps = async (
     // Parameters for slack
     const searchQuery: string | undefined =
       userDoc?.slack?.workspace?.[0]?.memberId;
-    const slackUserToken = `Bearer ${userDoc?.slack?.workspace?.[0]?.userToken}`;
+    const slackUserToken = `Bearer ${userDoc?.slack?.workspace?.[0]?.accessToken}`;
 
     // Tabulate number of times a user has been mentioned in all slack public channels
     const numberOfMentioned = await slackSearchFromServer(

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
-<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-13T08:54:42.807Z</lastmod></url>
+<url><loc>https://workstats.dev</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/cancel-membership</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-asana-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/help/how-to-get-github-info</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/privacy-policy</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/terms-of-service</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/user-list</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
+<url><loc>https://workstats.dev/user-settings</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2022-06-21T04:54:39.626Z</lastmod></url>
 </urlset>

--- a/services/asanaServices.client.tsx
+++ b/services/asanaServices.client.tsx
@@ -36,7 +36,8 @@ const requestAsanaUserIdentity = () => {
   }
   const params: PramsTypes = {
     client_id: process.env.NEXT_PUBLIC_ASANA_CLIENT_ID || '',
-    redirect_uri: process.env.NEXT_PUBLIC_ASANA_REDIRECT_URI || '',
+    redirect_uri:
+      `${process.env.NEXT_PUBLIC_ORIGIN}/user-settings?asana=true` || '',
     response_type: 'code',
     state: unguessableRandomString(16),
     // code_challenge_method: 'S256',

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -19,6 +19,7 @@ const handleSubmitBasicInfo = async (
   const docData: UserType = {
     assessor: event.currentTarget.assessor.value,
     assignedPj: event.currentTarget.assignedPj.value,
+    companyName: event.currentTarget.companyName.value,
     department: event.currentTarget.department.value,
     firstName: event.currentTarget.firstName.value,
     lastName: event.currentTarget.lastName.value,
@@ -134,6 +135,29 @@ const handleSubmitTaskTicket = async (
   return;
 };
 
+const handleSubmitSlackAccessToken = async (
+  docId: string,
+  accessToken: string,
+  userId: string,
+  workspaceName: string
+) => {
+  const docRef = doc(db, 'users', docId);
+  const docData: UserType = {
+    slack: {
+      workspace: [
+        {
+          accessToken: accessToken,
+          memberId: userId,
+          workspaceName: workspaceName
+        }
+      ]
+    }
+  };
+  const option = { merge: true };
+  await setDoc(docRef, docData, option);
+  return;
+};
+
 const handleSubmitCommunicationActivity = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
@@ -145,15 +169,11 @@ const handleSubmitCommunicationActivity = async (
       workspace: [
         {
           workspaceName: event.currentTarget.slackWorkspaceName1.value,
-          memberId: event.currentTarget.slackWorkspaceMemberId1.value,
-          userToken: event.currentTarget.slackWorkspaceUserToken1.value,
-          botToken: event.currentTarget.slackWorkspaceBotToken1.value
+          memberId: event.currentTarget.slackWorkspaceMemberId1.value
         },
         {
           workspaceName: event.currentTarget.slackWorkspaceName2.value,
-          memberId: event.currentTarget.slackWorkspaceMemberId2.value,
-          userToken: event.currentTarget.slackWorkspaceUserToken2.value,
-          botToken: event.currentTarget.slackWorkspaceBotToken2.value
+          memberId: event.currentTarget.slackWorkspaceMemberId2.value
         }
       ]
     }
@@ -197,6 +217,7 @@ export {
   handleSubmitSourceCode,
   handleSubmitAsanaAccessToken,
   handleSubmitTaskTicket,
+  handleSubmitSlackAccessToken,
   handleSubmitCommunicationActivity,
   handleSubmitSurveyWhyYouLeave
 };

--- a/services/slackServices.client.ts
+++ b/services/slackServices.client.ts
@@ -1,0 +1,35 @@
+// Request a user's Slack identity
+// THe official document is here https://api.slack.com/authentication/oauth-v2
+const requestSlackUserIdentity = () => {
+  // See about scope; https://api.slack.com/authentication/oauth-v2#asking
+  // Scope for bots is "scope", but for users it is "user_scope
+  const user_scope = 'channels:history,channels:read,search:read,users:read';
+  const unguessableRandomString = (outputLength: number) => {
+    const stringPool =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    return Array.from({ length: outputLength }, () =>
+      stringPool.charAt(Math.floor(Math.random() * stringPool.length))
+    ).join('');
+  };
+  interface PramsTypes {
+    user_scope: string;
+    client_id: string;
+    redirect_uri: string;
+    state: string;
+    // team: string;
+    [key: string]: string; // To avoid type error ts(7053) in params[key]
+  }
+  const params: PramsTypes = {
+    user_scope: user_scope,
+    client_id: process.env.NEXT_PUBLIC_SLACK_CLIENT_ID || '',
+    redirect_uri: process.env.NEXT_PUBLIC_SLACK_REDIRECT_URI || '',
+    state: unguessableRandomString(16)
+  };
+  const queryString = Object.keys(params)
+    .map((key) => `${key}=${encodeURIComponent(params[key])}`)
+    .join('&');
+  const url = `https://slack.com/oauth/v2/authorize?${queryString}`;
+  window.location.href = url;
+};
+
+export { requestSlackUserIdentity };

--- a/services/slackServices.client.ts
+++ b/services/slackServices.client.ts
@@ -22,7 +22,8 @@ const requestSlackUserIdentity = () => {
   const params: PramsTypes = {
     user_scope: user_scope,
     client_id: process.env.NEXT_PUBLIC_SLACK_CLIENT_ID || '',
-    redirect_uri: process.env.NEXT_PUBLIC_SLACK_REDIRECT_URI || '',
+    redirect_uri:
+      `${process.env.NEXT_PUBLIC_ORIGIN}/user-settings?slack=true` || '',
     state: unguessableRandomString(16)
   };
   const queryString = Object.keys(params)


### PR DESCRIPTION
## Problem

Until now, the linkage between Slack and WorkStats has been through user tokens. This meant that integration was only possible within the workspace in which the WorkStats app was currently registered, and could not be used in other workspaces. In other words, Slack data aggregation was virtually unusable.

## Solution

WorkStats now supports OAuth2.0 provided by Slack. This allows WorkStats to be used in any workspace. In addition, users can now simply click the "Integrate with Slack" button and configure the necessary settings for integration without having to do any research.

## Evidence

For desktop screen;

### 1. Open the User Settings page and press the "Connect with Slack" button

<img width="960" alt="2022-06-20 (7)" src="https://user-images.githubusercontent.com/4620828/174748177-a297d309-c5a4-4ea2-857f-9852fb6f36b7.png">

### 2. Enter the name of the workspace you want to log in to. To know the workspace ID you want to log in to, open that workspace and click on the workspace name in the upper left corner. The workspace ID will then be displayed.

<img width="960" alt="2022-06-20 (8)" src="https://user-images.githubusercontent.com/4620828/174749702-de27e398-10c1-4a71-9f39-da6794b2a900.png">
<img width="647" alt="2022-06-20 (18-2) (2)" src="https://user-images.githubusercontent.com/4620828/174780051-e4abed42-9e07-4c66-8e1e-dc47c2dc6cb1.png">
<img width="960" alt="2022-06-20 (9)" src="https://user-images.githubusercontent.com/4620828/174752523-3f701656-a319-4c06-88fa-33c80ff13de0.png">

### 3. Log in to Slack

<img width="960" alt="2022-06-20 (10)" src="https://user-images.githubusercontent.com/4620828/174752585-bd678e19-06b0-4ff3-861c-f004c395d395.png">

### 4-A. The scope required for aggregation in WorkStats will be displayed. (If the user is a Slack admin, or if the workspace is configured to not require authorization to install the app) Check it and if it is OK, click the "Allow" button. Then go to chapter 5.

<img width="960" alt="2022-06-20 (12)" src="https://user-images.githubusercontent.com/4620828/174752633-ecdaeb9f-9622-4bdc-84d8-1b0bf2ddef7e.png">

### 4-B. (If the user is not a Slack admin, and the workspace is configured to require Admin approval to install the app) A screen will appear asking you to submit a request to the Admin to install the WorkStats app. Clicking the Apply button will take you to an administration page where you will see that you are awaiting approval.

<img width="960" alt="2022-06-21 (7)" src="https://user-images.githubusercontent.com/4620828/174753197-332e7003-2b1d-47cd-b18d-94eb28e689d5.png">
<img width="960" alt="2022-06-21 (18-2)" src="https://user-images.githubusercontent.com/4620828/174782671-f9178a43-ec8d-445a-879e-3c2cc565928f.png">

#### 4-B-1. SlackBot will send a direct message to the Admin and the user needs to wait for the approval. Prompt the Admin as needed. For the Slack Admin, see the details here; https://slack.com/help/articles/360024269514-Manage-app-requests-for-your-workspace

<img width="915" alt="2022-06-21 (13)" src="https://user-images.githubusercontent.com/4620828/174756185-e921b2cc-e730-47e4-8236-c1c3124265fb.png">

#### 4-B-2. When the admin approves, installation of the WorkStats application has been authorized. Let's proceed with the installation procedure again!

<img width="456" alt="2022-06-21 (22)" src="https://user-images.githubusercontent.com/4620828/174784912-00133b5a-e8b6-4386-a843-ac68c91c26e8.png">

#### 4-B-3. The "Add to Slack" button will appear on the administration page of the WorkStats app and can be pressed. Pressing it will return you to the WorkStats user settings page. Alternatively, you may return directly to the WorkStats user settings page. Then Go to chapter 1, this time you will not be asked for approval to install the WorkStats app.

<img width="960" alt="2022-06-21 (20-2)" src="https://user-images.githubusercontent.com/4620828/174786547-e49e8287-a576-43cf-835e-81ee3add6634.png">

### 5. You will be redirected to the user settings screen. Then you will be notified that the integration between WorkStats and Slack is complete, and the screen will automatically reload when you click "OK

<img width="960" alt="2022-06-21 (2)" src="https://user-images.githubusercontent.com/4620828/174752810-1738c562-bf5d-49ba-86e5-fc8950dc73e1.png">

### 6. You can see the settings necessary for Slack to collect information

<img width="960" alt="2022-06-21 (3)" src="https://user-images.githubusercontent.com/4620828/174752917-86308732-c55d-4d41-a5b8-ce19f782f648.png">

### 7. Open the Dashboard page and confirm that Slack numbers are displayed

<img width="960" alt="2022-06-21 (14-2)" src="https://user-images.githubusercontent.com/4620828/174757418-b12f1583-270b-4b72-b4c9-6aab0e07f46c.png">

### 8. (If you want to disconnect the connection between Slack and WorkStats) Open the User Settings page and click the "Disconnect with Slack" button

<img width="960" alt="2022-06-21 (3)" src="https://user-images.githubusercontent.com/4620828/174753025-fe3fd47c-71e7-40c0-aae2-b21ae6c6f89a.png">

### 9. Click OK when you see the message "Disconnection completed.

<img width="960" alt="2022-06-21 (4)" src="https://user-images.githubusercontent.com/4620828/174752962-53f9b9a5-2b15-40a2-9da1-0076334fa556.png">

### 10. You can confirm that the registered linkage information has disappeared.

<img width="960" alt="2022-06-21 (5)" src="https://user-images.githubusercontent.com/4620828/174753089-0b809709-2694-4d2e-afcb-d236698133de.png">

### Environment Variables Setting

Do you require registration to the following console screens other than the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions: Necessary


- Vercel Hosting: Necessary


- Firebase Console: No
- Google Cloud Platform: No
- Asana Developer Console: No
- Slack Developer Console: Necessary


## Caveats

As of June 2022, the redirect URI specified in the Slack app console screen will not allow http and must use https to register. This validation applies even when using localhost in the development environment. However, localhost usually does not support https, and if you try to open the page using Google Chrome, for example, it will not open. Therefore, when redirected, in the development environment, the https part must be manually changed to http and reloaded manually. We do not believe that a way to avoid this hassle does not exist, but once we allow this manual work.

## References

No need to read these links, but I'll leave them as a note

### For OAuth

https://api.slack.com/authentication/basics
https://api.slack.com/authentication/oauth-v2
https://api.slack.com/methods/oauth.v2.access
https://api.slack.com/methods/auth.revoke

### For Scopes

https://api.slack.com/methods/search.messages
https://api.slack.com/methods/conversations.history
https://api.slack.com/methods/conversations.list
https://api.slack.com/methods/conversations.replies

### For App Installation Setting

https://workstatsdevelopment.slack.com/apps/manage/settings
https://app.slack.com/apps-manage/T03KL9DE3UK/integrations/installed
https://slack.com/help/articles/360024269514-Manage-app-requests-for-your-workspace