### PR TITLE
Changed the timing of tallying number of mentioned from the time of request to after the render.

### DIFF
--- a/components/cards/CardList.tsx
+++ b/components/cards/CardList.tsx
@@ -20,9 +20,9 @@ import VelocityOfTaskClose from './VelocityOfTaskClose';
 import GearIconLink from '../common/GearIcon';
 import { useNumberOfTasks } from '../../services/asanaServices.client';
 import EstimatedDateOfCompletion from './EstimatedDateOfTaskEnd';
+import { useNumberOfMentioned } from '../../services/slackServices.client';
 
 interface PropTypes {
-  numberOfMentioned: number;
   numberOfNewSent: number;
   numberOfReplies: number;
   asanaWorkspaceId: string;
@@ -34,12 +34,13 @@ interface PropTypes {
   githubUserId: number;
   githubUserName: string;
   githubAccessToken: string;
+  slackAccessToken: string;
+  searchQuery: string;
   uid: string;
 }
 
 // @ts-ignore
 const CardList = ({
-  numberOfMentioned,
   numberOfNewSent,
   numberOfReplies,
   asanaWorkspaceId,
@@ -51,6 +52,8 @@ const CardList = ({
   githubUserId,
   githubUserName,
   githubAccessToken,
+  slackAccessToken,
+  searchQuery,
   uid
 }: PropTypes) => {
   // const numberOfMeetings = 0;
@@ -61,6 +64,10 @@ const CardList = ({
     asanaRefreshToken,
     uid
   );
+  const numberOfMentioned = useNumberOfMentioned({
+    searchQuery,
+    slackAccessToken
+  });
 
   return (
     <>

--- a/components/cards/NumberOfMentioned.tsx
+++ b/components/cards/NumberOfMentioned.tsx
@@ -27,12 +27,12 @@ const NumberOfMentioned = ({ data }) => {
             # of mentioned
           </div>
           <div className='hidden md:contents md:text-2xl md:font-bold md:text-gray-900'>
-            {data.messages?.total ? data.messages?.total : 0} times
+            {data ? data : 0} times
           </div>
         </div>
       </div>
       <div className='md:hidden text-xl font-bold text-gray-900'>
-        {data.messages?.total ? data.messages?.total : 0} times
+        {data ? data : 0} times
       </div>
     </div>
   );

--- a/pages/api/search-slack.ts
+++ b/pages/api/search-slack.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// The official document is here: https://api.slack.com/methods/search.messages
+// Rate limit is Tier 2: 20+ requests per minute.
+const SearchSlack = async (req: NextApiRequest, res: NextApiResponse) => {
+  const url = `https://slack.com/api/search.messages?query=${req.body.searchQuery}`;
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: req.body.slackAccessToken,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  })
+    .then((res) => res.json())
+    .catch((err) => {
+      console.log({ err });
+      return err;
+    });
+  res.status(200).json(response);
+};
+
+export default SearchSlack;

--- a/services/githubServices.client.tsx
+++ b/services/githubServices.client.tsx
@@ -3,10 +3,10 @@ import useSWR from 'swr';
 // HTTP endpoint v3 (REST API)
 const base = 'https://api.github.com';
 const options = {
-  shouldRetryOnError: false,
-  revalidateIfStale: false,
-  revalidateOnFocus: false,
-  revalidateOnReconnect: false
+  shouldRetryOnError: false, // Default is true
+  revalidateIfStale: false, // Default is true
+  revalidateOnFocus: false, // Default is true
+  revalidateOnReconnect: false // Default is true
 };
 
 // Request a user's GitHub identity

--- a/services/slackServices.client.ts
+++ b/services/slackServices.client.ts
@@ -1,3 +1,14 @@
+import useSWR from 'swr';
+
+// This is useSWR's options, the document is here: https://swr.vercel.app/docs/options
+const options = {
+  shouldRetryOnError: true, // Default is true. If this is false, it doesn't work because data returns undefined for some reason.
+  revalidateIfStale: true, // Default is true
+  // revalidateOnMount: false,
+  revalidateOnFocus: true, // Default is true
+  revalidateOnReconnect: true // Default is true
+};
+
 // Request a user's Slack identity
 // THe official document is here https://api.slack.com/authentication/oauth-v2
 const requestSlackUserIdentity = () => {
@@ -33,4 +44,44 @@ const requestSlackUserIdentity = () => {
   window.location.href = url;
 };
 
-export { requestSlackUserIdentity };
+interface NumberOfMentionedTypes {
+  searchQuery: string;
+  slackAccessToken: string;
+}
+
+// Aggregate how many times a user is mentioned in a workspace
+// Slack API must be used in a server-side, so we call this method in a browser first then call Next.js API which wraps Slack API
+const useNumberOfMentioned = ({
+  searchQuery,
+  slackAccessToken
+}: NumberOfMentionedTypes) => {
+  const apiEndPoint = '/api/search-slack';
+  const headers = new Headers();
+  headers.append('Accept', 'application/json');
+  headers.append('Content-Type', 'application/json');
+  const body = {
+    searchQuery,
+    slackAccessToken
+  };
+  const fetchOptions = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  };
+  const fetcher = async (url: string) => {
+    const response = await fetch(url, fetchOptions);
+    const json = await response.json();
+    const output: number = json.messages.total;
+    return output;
+  };
+  const { data, error } = useSWR(apiEndPoint, fetcher, options);
+  if (error) {
+    return 0;
+  } else if (!data) {
+    return 0;
+  } else {
+    return data;
+  }
+};
+
+export { useNumberOfMentioned, requestSlackUserIdentity };

--- a/services/slackServices.server.tsx
+++ b/services/slackServices.server.tsx
@@ -1,19 +1,3 @@
-// Slack API method: search.messages
-const slackSearchFromServer = async (searchQuery: string, token: string) => {
-  // Common part of each function
-  const myHeaders = new Headers();
-  myHeaders.append('Authorization', token);
-  myHeaders.append('Content-Type', 'application/x-www-form-urlencoded');
-
-  // This URL itself will be changed to a temporary argument later.
-  const slackURL = `https://slack.com/api/search.messages?query=${searchQuery}`;
-  const res = await fetch(slackURL, {
-    headers: myHeaders
-  });
-  const data = await res.json();
-  return data;
-};
-
 // Slack API method: conversation.history
 // Obtain the number of times a user has posted a new message on a given channel
 const slackConversationHistory = async (
@@ -132,7 +116,6 @@ const postMessageToSlack = async () => {
 };
 
 export {
-  slackSearchFromServer,
   slackConversationHistory,
   slackConversationList,
   countRepliesInSlack,


### PR DESCRIPTION
## Problem

Since the Slack API violates CORS constraints and causes an error if not called from the server-side, Slack-related aggregation was done on the server-side at request time, but the calculation time is long. Therefore, the start of rendering is slow. I didn't know how to solve this problem at the time. This can be solved by using Next/API, which allows the server-side program to run after rendering.

## Solution

We solved the Slack API CORS constraint by wrapping the Slack API in Next/API and calling that Next/API from the browser.
There are several Slack-related functions, but we first solved one simple one.

## Evidence

For desktop screen;

|Before|
|---|
|![image](https://user-images.githubusercontent.com/4620828/175917573-e7c46d4a-b4e2-471a-9472-9e7dd031cece.png)|

|After|
|---|
|![image](https://user-images.githubusercontent.com/4620828/175922366-eeee3931-446e-497a-a1e8-63c95cf22c06.png)|

### Environment Variables Setting

Do you require registration to the following console screens other than the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions: No
- Vercel Hosting: No
- Firebase Console: No
- Google Cloud Platform: No
- Asana Developer Console: No
- Slack Developer Console: No

## Caveats

No

## References

No
