### PR TITLE
Changed to store aggregated GitHub numbers in Firestore and display those values on first render

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ For desktop screens;
 
 ### Environment Variables Setting
 
-Do you require registration to the following console screens other than the source code? If so, please attach evidence of registration to each of the console screens below.
+Do you require registration for the following console screens beside the source code? If so, please attach evidence of registration to each of the console screens below.
 
 - GitHub Actions: 
 - Vercel Hosting: 
@@ -37,8 +37,10 @@ Do you require registration to the following console screens other than the sour
 
 ## Performance
 
-For desktop screen, DOM Content Loaded Speed;
-Changed x.xx (s) --> x.xx (s), improved about x.x seconds.
+For desktop screen,
+
+- DOM Content Loaded Speed: x.xx (s) --> x.xx (s), -xxx (ms)
+- Finish: x.xx (s) --> x.xx (s), -xxx (ms)
 
 |Chrome Developer Console Network Tab (Before)|
 |---|

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,19 @@ Do you require registration to the following console screens other than the sour
 - Asana Developer Console: 
 - Slack Developer Console: 
 
+## Performance
+
+For desktop screen, DOM Content Loaded Speed;
+Changed x.xx (s) --> x.xx (s), improved about x.x seconds.
+
+|Chrome Developer Console Network Tab (Before)|
+|---|
+|---|
+
+|Chrome Developer Console Network Tab (After)|
+|---|
+|---|
+
 ## Caveats
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ yarn-error.log*
 
 # firebase admin
 secrets.json
-
-# test data for admin
-services/setAUserDocToFirebase.js

--- a/components/cards/NumberOfCommits.tsx
+++ b/components/cards/NumberOfCommits.tsx
@@ -1,25 +1,8 @@
-import { useNumberOfCommits } from '../../services/githubServices.client';
-
 interface PropTypes {
-  githubOwnerName: string;
-  githubRepoName: string;
-  githubUserId: number;
-  githubAccessToken: string;
+  data: number;
 }
 
-const NumberOfCommits = ({
-  githubOwnerName,
-  githubRepoName,
-  githubUserId,
-  githubAccessToken
-}: PropTypes) => {
-  const data = useNumberOfCommits(
-    githubOwnerName,
-    githubRepoName,
-    githubUserId,
-    githubAccessToken
-  );
-
+const NumberOfCommits = ({ data }: PropTypes) => {
   return (
     <div className='bg-white shadow rounded-lg p-3 md:p-4 hover:bg-slate-200'>
       <div className='flex space-x-4 items-center'>

--- a/components/cards/NumberOfPullRequests.tsx
+++ b/components/cards/NumberOfPullRequests.tsx
@@ -1,24 +1,8 @@
-import { useNumberOfPullRequests } from '../../services/githubServices.client';
-
 interface PropTypes {
-  githubOwnerName: string;
-  githubRepoName: string;
-  githubUserId: number;
-  githubAccessToken: string;
+  data: number;
 }
 
-const NumberOfPullRequests = ({
-  githubOwnerName,
-  githubRepoName,
-  githubUserId,
-  githubAccessToken
-}: PropTypes) => {
-  const data = useNumberOfPullRequests(
-    githubOwnerName,
-    githubRepoName,
-    githubUserId,
-    githubAccessToken
-  );
+const NumberOfPullRequests = ({ data }: PropTypes) => {
   return (
     <div className='bg-white shadow rounded-lg p-3 md:p-4 hover:bg-slate-200'>
       <div className='flex space-x-4 items-center'>

--- a/components/cards/NumberOfReview.tsx
+++ b/components/cards/NumberOfReview.tsx
@@ -1,25 +1,8 @@
-import { useNumberOfReviews } from '../../services/githubServices.client';
-
 interface PropTypes {
-  githubOwnerName: string;
-  githubRepoName: string;
-  githubUserName: string;
-  githubAccessToken: string;
+  data: number;
 }
 
-const NumberOfReviews = ({
-  githubOwnerName,
-  githubRepoName,
-  githubUserName,
-  githubAccessToken
-}: PropTypes) => {
-  const data = useNumberOfReviews(
-    githubOwnerName,
-    githubRepoName,
-    githubUserName,
-    githubAccessToken
-  );
-  // console.log(`data is: ${data}`);
+const NumberOfReviews = ({ data }: PropTypes) => {
   return (
     <div className='bg-white shadow rounded-lg p-3 md:p-4 hover:bg-slate-200'>
       <div className='flex space-x-4 items-center'>

--- a/config/firebaseTypes.ts
+++ b/config/firebaseTypes.ts
@@ -42,4 +42,18 @@ interface UserType extends Record<string, unknown> {
   supervisor?: string;
 }
 
-export type { UserType };
+interface NumbersType extends Record<string, unknown> {
+  github: {
+    numberOfCommits: {
+      allPeriods: number;
+    };
+    numberOfPullRequests: {
+      allPeriods: number;
+    };
+    numberOfReviews: {
+      allPeriods: number;
+    };
+  };
+}
+
+export type { UserType, NumbersType };

--- a/config/firebaseTypes.ts
+++ b/config/firebaseTypes.ts
@@ -43,7 +43,27 @@ interface UserType extends Record<string, unknown> {
 }
 
 interface NumbersType extends Record<string, unknown> {
-  github: {
+  asana?: {
+    numberOfTasks: {
+      allPeriods: number;
+    };
+    numberOfTasksClosed: {
+      allPeriods: number;
+    };
+    numberOfTasksOpen: {
+      allPeriods: number;
+    };
+    velocityPerDay: {
+      allPeriods: number;
+    };
+    velocityPerWeek: {
+      allPeriods: number;
+    };
+    estimatedCompletionDate: {
+      allPeriods: string;
+    };
+  };
+  github?: {
     numberOfCommits: {
       allPeriods: number;
     };
@@ -51,6 +71,20 @@ interface NumbersType extends Record<string, unknown> {
       allPeriods: number;
     };
     numberOfReviews: {
+      allPeriods: number;
+    };
+  };
+  slack?: {
+    numberOfMentioned: {
+      allPeriods: number;
+    };
+    numberOfNewSent: {
+      allPeriods: number;
+    };
+    numberOfTotalSent: {
+      allPeriods: number;
+    };
+    numberOfReplies: {
       allPeriods: number;
     };
   };

--- a/pages/cancel-membership.tsx
+++ b/pages/cancel-membership.tsx
@@ -6,7 +6,7 @@ import Head from 'next/head';
 
 // Firebase related
 import { verifyIdToken } from '../firebaseAdmin';
-import getAUserDoc from '../services/getAUserDocFromFirebase';
+import { getAUserDoc } from '../services/getDocFromFirestore';
 import { UserType } from '../config/firebaseTypes';
 
 // Components and Services

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,7 +5,7 @@ import nookies from 'nookies';
 
 // Config
 import { verifyIdToken } from '../firebaseAdmin';
-import { UserType } from '../config/firebaseTypes';
+import { NumbersType, UserType } from '../config/firebaseTypes';
 
 // Components
 import ProfileList from '../components/common/ProfileList';
@@ -15,7 +15,7 @@ import ButtonList from '../components/buttons/ButtonList';
 import SpecifyPeriodFromTo from '../components/buttons/SpecifyPeriodFromTo';
 
 // Services
-import getAUserDoc from '../services/getAUserDocFromFirebase';
+import { getAUserDoc, getANumbersDoc } from '../services/getDocFromFirestore';
 
 interface PropTypes {
   asanaWorkspaceId: string;
@@ -27,6 +27,7 @@ interface PropTypes {
   githubUserId: number;
   githubUserName: string;
   githubAccessToken: string;
+  numbersDoc: NumbersType;
   profileList: UserType;
   slackAccessToken: string;
   slackMemberId: string;
@@ -43,6 +44,7 @@ export default function Home({
   githubUserId,
   githubUserName,
   githubAccessToken,
+  numbersDoc,
   profileList,
   slackAccessToken,
   slackMemberId,
@@ -75,6 +77,7 @@ export default function Home({
               githubUserId={githubUserId}
               githubUserName={githubUserName}
               githubAccessToken={githubAccessToken}
+              numbersDoc={numbersDoc}
               slackAccessToken={slackAccessToken}
               slackMemberId={slackMemberId}
               uid={uid}
@@ -100,6 +103,7 @@ export const getServerSideProps: GetServerSideProps = async (
     // the user is authenticated!
     const { uid } = token;
     const userDoc = await getAUserDoc(uid);
+    const numbersDoc = await getANumbersDoc(uid);
 
     // Profile list to be displayed on the left side
     const profileList = {
@@ -159,6 +163,7 @@ export const getServerSideProps: GetServerSideProps = async (
         githubUserId,
         githubUserName,
         githubAccessToken,
+        numbersDoc,
         profileList,
         slackAccessToken,
         slackMemberId,

--- a/pages/user-settings.tsx
+++ b/pages/user-settings.tsx
@@ -12,7 +12,7 @@ import InputBox from '../components/boxes/InputBox';
 import SubmitButton from '../components/buttons/SubmitButton';
 import { UserType } from '../config/firebaseTypes';
 import { verifyIdToken } from '../firebaseAdmin';
-import getAUserDoc from '../services/getAUserDocFromFirebase';
+import { getAUserDoc } from '../services/getDocFromFirestore';
 import {
   handleSubmitAsanaAccessToken,
   handleSubmitBasicInfo,

--- a/services/getDocFromFirestore.ts
+++ b/services/getDocFromFirestore.ts
@@ -11,13 +11,28 @@ const getAUserDoc = async (docId: string) => {
       ...docSnap.data(),
       documentId: docSnap.id
     };
-    // console.log("Document data:", result);
     return result;
   } else {
-    // doc.data() will be undefined in this case
     console.log('No such document!');
     return;
   }
 };
 
-export default getAUserDoc;
+const getANumbersDoc = async (docId: string) => {
+  const docRef = doc(db, 'numbers', docId);
+  const docSnap = await getDoc(docRef);
+  return docSnap.data();
+
+  if (docSnap.exists()) {
+    const result: UserType = {
+      ...docSnap.data(),
+      documentId: docSnap.id
+    };
+    return result;
+  } else {
+    console.log('No such document!');
+    return;
+  }
+};
+
+export { getANumbersDoc, getAUserDoc };

--- a/services/githubServices.client.tsx
+++ b/services/githubServices.client.tsx
@@ -206,7 +206,7 @@ const useNumberOfReviews = (
 ): number => {
   const params = {
     q: `is:pr repo:${owner}/${repo} reviewed-by:${githubUserName}`,
-    per_page: '10', // max = 100
+    per_page: '100', // max = 100
     page: '1'
   };
   const query = new URLSearchParams(params);

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -241,6 +241,88 @@ const UpdInsGithubNumbers = async ({
   return;
 };
 
+interface UpdInsAsanaNumbersProps {
+  docId: string;
+  numberOfTasksAllPeriods: number;
+  numberOfTasksClosedAllPeriods: number;
+  numberOfTasksOpenAllPeriods: number;
+  velocityPerDayAllPeriods: number;
+  velocityPerWeekAllPeriods: number;
+  estimatedCompletionDateAllPeriods: string;
+}
+const UpdInsAsanaNumbers = async ({
+  docId,
+  numberOfTasksAllPeriods,
+  numberOfTasksClosedAllPeriods,
+  numberOfTasksOpenAllPeriods,
+  velocityPerDayAllPeriods,
+  velocityPerWeekAllPeriods,
+  estimatedCompletionDateAllPeriods
+}: UpdInsAsanaNumbersProps) => {
+  const docRef = doc(db, 'numbers', docId);
+  const docData: NumbersType = {
+    asana: {
+      numberOfTasks: {
+        allPeriods: numberOfTasksAllPeriods
+      },
+      numberOfTasksClosed: {
+        allPeriods: numberOfTasksClosedAllPeriods
+      },
+      numberOfTasksOpen: {
+        allPeriods: numberOfTasksOpenAllPeriods
+      },
+      velocityPerDay: {
+        allPeriods: velocityPerDayAllPeriods
+      },
+      velocityPerWeek: {
+        allPeriods: velocityPerWeekAllPeriods
+      },
+      estimatedCompletionDate: {
+        allPeriods: estimatedCompletionDateAllPeriods
+      }
+    }
+  };
+  const option = { merge: true };
+  await setDoc(docRef, docData, option);
+  return;
+};
+
+interface UpdInsSlackNumbersProps {
+  docId: string;
+  numberOfMentionedAllPeriods: number;
+  numberOfNewSentAllPeriods: number;
+  numberOfTotalSentAllPeriods: number;
+  numberOfRepliesAllPeriods: number;
+}
+const UpdInsSlackNumbers = async ({
+  docId,
+  numberOfMentionedAllPeriods,
+  numberOfNewSentAllPeriods,
+  numberOfTotalSentAllPeriods,
+  numberOfRepliesAllPeriods
+}: UpdInsSlackNumbersProps) => {
+  const docRef = doc(db, 'numbers', docId);
+  const docData: NumbersType = {
+    slack: {
+      numberOfMentioned: {
+        allPeriods: numberOfMentionedAllPeriods
+      },
+      numberOfNewSent: {
+        allPeriods: numberOfNewSentAllPeriods
+      },
+      numberOfTotalSent: {
+        allPeriods: numberOfTotalSentAllPeriods
+      },
+      numberOfReplies: {
+        allPeriods: numberOfRepliesAllPeriods
+      }
+    }
+  };
+  const option = { merge: true };
+  await setDoc(docRef, docData, option);
+  return;
+};
+
 export {
   createUserDoc,
   handleSubmitBasicInfo,
@@ -251,5 +333,7 @@ export {
   handleSubmitSlackAccessToken,
   handleSubmitCommunicationActivity,
   handleSubmitSurveyWhyYouLeave,
-  UpdInsGithubNumbers
+  UpdInsAsanaNumbers,
+  UpdInsGithubNumbers,
+  UpdInsSlackNumbers
 };

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -1,6 +1,6 @@
 import { doc, setDoc } from 'firebase/firestore';
 import { db } from '../config/firebaseClient';
-import { UserType } from '../config/firebaseTypes';
+import { NumbersType, UserType } from '../config/firebaseTypes';
 
 const createUserDoc = async (docId: string) => {
   const docRef = doc(db, 'users', docId);
@@ -210,6 +210,37 @@ const handleSubmitSurveyWhyYouLeave = async (
   return;
 };
 
+interface UpdInsGithubNumbersProps {
+  docId: string;
+  numberOfCommitsAllPeriods: number;
+  numberOfPullRequestsAllPeriods: number;
+  numberOfReviewsAllPeriods: number;
+}
+const UpdInsGithubNumbers = async ({
+  docId,
+  numberOfCommitsAllPeriods,
+  numberOfPullRequestsAllPeriods,
+  numberOfReviewsAllPeriods
+}: UpdInsGithubNumbersProps) => {
+  const docRef = doc(db, 'numbers', docId);
+  const docData: NumbersType = {
+    github: {
+      numberOfCommits: {
+        allPeriods: numberOfCommitsAllPeriods
+      },
+      numberOfPullRequests: {
+        allPeriods: numberOfPullRequestsAllPeriods
+      },
+      numberOfReviews: {
+        allPeriods: numberOfReviewsAllPeriods
+      }
+    }
+  };
+  const option = { merge: true };
+  await setDoc(docRef, docData, option);
+  return;
+};
+
 export {
   createUserDoc,
   handleSubmitBasicInfo,
@@ -219,5 +250,6 @@ export {
   handleSubmitTaskTicket,
   handleSubmitSlackAccessToken,
   handleSubmitCommunicationActivity,
-  handleSubmitSurveyWhyYouLeave
+  handleSubmitSurveyWhyYouLeave,
+  UpdInsGithubNumbers
 };


### PR DESCRIPTION
## Problem

This is not limited to GitHub, but the system was initially designed to tally the numbers after each render and re-render and display them later. This caused two problems: for example, even numbers that had just been calculated took a long time to appear because they had to be calculated again when reloaded. The problem became more pronounced when a button was implemented to change the aggregation period in the future.

## Solution

As the title says, I changed to store aggregated GitHub numbers in Firestore and display those values on the first render.

## Evidence

For desktop screens;

|Before|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177025915-77f48ec2-4abb-4ffe-aadb-ec7b7e71508a.png)|

|After|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177025953-da39fb9a-4ae2-42d4-8ac9-6f049b9e4b65.png)|

### Environment Variables Setting

Do you require registration for the following console screens beside the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions: No
- Vercel Hosting: No
- Firebase Console: No
- Google Cloud Platform: No
- Asana Developer Console: No
- Slack Developer Console: No

## Performance

For desktop screen,

- DOM Content Loaded Speed: 3.65 (s) --> 3.26 (s) --> 2.22 (s), -1,430 (ms)
- Finish: 14.66 (s) --> 9.19 (s) --> 7.75 (s), -6,910 (ms)

|Chrome Developer Console Network Tab (Before)|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177026251-45081d48-51df-405e-bede-85f329df519c.png)|

|Chrome Developer Console Network Tab (After 1st Commit)|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177026236-800a6c4c-a954-4a72-aeec-907147f16985.png)|

|Chrome Developer Console Network Tab (After 2nd Commit)|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177029260-d7c80ac9-76f0-4981-a17c-9172ad7bea07.png)|

## Caveats

No

## References

No
