### PR TITLE
Hotfilx: Fixed a bug that the numbers were once set to 0 when the Asana API access token expired after 1 hour.

### DIFF
--- a/components/cards/CardList.tsx
+++ b/components/cards/CardList.tsx
@@ -131,8 +131,11 @@ const CardList = ({
   const [estimatedCompletionDate, setEstimatedCompletionDate] = useState(
     numbersDoc.asana?.estimatedCompletionDate.allPeriods || '--'
   );
+  const [asanaAccessToken, setAsanaAccessToken] = useState(
+    asanaOAuthAccessToken
+  );
   const numberOfTasksCalc = useNumberOfTasks(
-    asanaOAuthAccessToken,
+    asanaAccessToken,
     asanaWorkspaceId,
     asanaUserId,
     asanaRefreshToken,
@@ -145,6 +148,7 @@ const CardList = ({
     setVelocityPerDay(numberOfTasksCalc.velocityPerDays);
     setVelocityPerWeek(numberOfTasksCalc.velocityPerWeeks);
     setEstimatedCompletionDate(numberOfTasksCalc.estimatedCompletionDate);
+    setAsanaAccessToken(numberOfTasksCalc.asanaAccessToken);
   }, [numberOfTasksCalc]);
   useEffect(() => {
     UpdInsAsanaNumbers({

--- a/services/asanaServices.client.tsx
+++ b/services/asanaServices.client.tsx
@@ -93,6 +93,7 @@ const useNumberOfTasks = (
   uid?: string
 ) => {
   const token = asanaAccessToken;
+  let newAsanaAccessToken = '';
   const myHeaders = new Headers();
   myHeaders.append('Accept', 'application/json');
   myHeaders.append('Authorization', 'Bearer ' + token);
@@ -115,16 +116,17 @@ const useNumberOfTasks = (
     const response = await fetch(url, {
       headers: myHeaders
     })
-      .then((res) => {
+      .then(async (res) => {
         // if res.status is 401, which means Unauthorized, then refresh the access token and try again
         if (res.status === 401 && asanaRefreshToken && uid) {
-          refreshAccessToken(asanaRefreshToken)
+          return refreshAccessToken(asanaRefreshToken)
             .then(async (res) => {
+              newAsanaAccessToken = res.access_token;
               await handleSubmitAsanaAccessToken(uid, res.access_token);
               myHeaders.set('Authorization', 'Bearer ' + res.access_token);
             })
             .then(async () => {
-              await fetch(url, {
+              return await fetch(url, {
                 headers: myHeaders
               }).then((res) => res.json());
             });
@@ -167,6 +169,9 @@ const useNumberOfTasks = (
       .format('MMM D YYYY');
 
     const output = {
+      asanaAccessToken: newAsanaAccessToken
+        ? newAsanaAccessToken
+        : asanaAccessToken,
       numberOfAll: numberOfAll,
       numberOfClosed: numberOfClosed ? numberOfClosed : 0,
       numberOfOpened: numberOfOpened ? numberOfOpened : 0,
@@ -188,6 +193,7 @@ const useNumberOfTasks = (
   });
 
   const noResults = {
+    asanaAccessToken,
     numberOfAll: 0,
     numberOfClosed: 0,
     numberOfOpened: 0,


### PR DESCRIPTION
## Problem

The Asana API access token expires in one hour. Therefore, when the API is called after expiration, a 401 error is returned, in which case there is a process to refresh the token. However, in fact, we had implemented a process to update the DB with the refreshed access token and call the API again with the new access token, but we had not used the return value.

## Solution

Returns were added.

## Evidence

For desktop screens;

|Before|
|---|
|<img width="960" alt="image" src="https://user-images.githubusercontent.com/4620828/177039334-1cd4f9b3-bc83-46aa-a90f-754110eab15f.png">|

|After|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177039353-b7760721-9549-47db-819f-89e79d0b0c6b.png)|

### Environment Variables Setting

Do you require registration for the following console screens beside the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions: No
- Vercel Hosting: No
- Firebase Console: No
- Google Cloud Platform: No
- Asana Developer Console: No
- Slack Developer Console: No

## Performance

Not relevant

## Caveats

No

## References

No
