### PR TITLE
Hotfix: Fixed a bug that caused an error for new users due to a new table.

### DIFF
--- a/components/cards/CardList.tsx
+++ b/components/cards/CardList.tsx
@@ -71,13 +71,13 @@ const CardList = ({
 }: PropTypes) => {
   // const numberOfMeetings = 0;
   const [numberOfCommits, setNumberOfCommits] = useState(
-    numbersDoc.github?.numberOfCommits.allPeriods || 0
+    numbersDoc?.github?.numberOfCommits.allPeriods || 0
   );
   const [numberOfPullRequests, setNumberOfPullRequests] = useState(
-    numbersDoc.github?.numberOfPullRequests.allPeriods || 0
+    numbersDoc?.github?.numberOfPullRequests.allPeriods || 0
   );
   const [numberOfReviews, setNumberOfReviews] = useState(
-    numbersDoc.github?.numberOfReviews.allPeriods || 0
+    numbersDoc?.github?.numberOfReviews.allPeriods || 0
   );
   const numberOfCommitsCalc = useNumberOfCommits(
     githubOwnerName,
@@ -114,22 +114,22 @@ const CardList = ({
 
   // Aggregate numbers from Asana
   const [numberOfTasks, setNumberOfTasks] = useState(
-    numbersDoc.asana?.numberOfTasks.allPeriods || 0
+    numbersDoc?.asana?.numberOfTasks.allPeriods || 0
   );
   const [numberOfTasksClosed, setNumberOfTasksClosed] = useState(
-    numbersDoc.asana?.numberOfTasksClosed.allPeriods || 0
+    numbersDoc?.asana?.numberOfTasksClosed.allPeriods || 0
   );
   const [numberOfTasksOpen, setNumberOfTasksOpen] = useState(
-    numbersDoc.asana?.numberOfTasksOpen.allPeriods || 0
+    numbersDoc?.asana?.numberOfTasksOpen.allPeriods || 0
   );
   const [velocityPerDay, setVelocityPerDay] = useState(
-    numbersDoc.asana?.velocityPerDay.allPeriods || 0
+    numbersDoc?.asana?.velocityPerDay.allPeriods || 0
   );
   const [velocityPerWeek, setVelocityPerWeek] = useState(
-    numbersDoc.asana?.velocityPerWeek.allPeriods || 0
+    numbersDoc?.asana?.velocityPerWeek.allPeriods || 0
   );
   const [estimatedCompletionDate, setEstimatedCompletionDate] = useState(
-    numbersDoc.asana?.estimatedCompletionDate.allPeriods || '--'
+    numbersDoc?.asana?.estimatedCompletionDate.allPeriods || '--'
   );
   const [asanaAccessToken, setAsanaAccessToken] = useState(
     asanaOAuthAccessToken
@@ -172,10 +172,10 @@ const CardList = ({
 
   // Aggregate numbers from Slack
   const [numberOfMentioned, setNumberOfMentioned] = useState(
-    numbersDoc.slack?.numberOfMentioned.allPeriods || 0
+    numbersDoc?.slack?.numberOfMentioned.allPeriods || 0
   );
   const [numberOfTotalSent, setNumberOfTotalSent] = useState(
-    numbersDoc.slack?.numberOfTotalSent.allPeriods || 0
+    numbersDoc?.slack?.numberOfTotalSent.allPeriods || 0
   );
   const numberOfTotalSentCalc = useSlackSearch({
     slackMemberId,
@@ -193,10 +193,10 @@ const CardList = ({
   }, [numberOfMentionedCalc, numberOfTotalSentCalc]);
   const slackChannelList = useSlackChannelList({ slackAccessToken });
   const [numberOfNewSent, setNumberOfNewSent] = useState(
-    numbersDoc.slack?.numberOfNewSent.allPeriods || 0
+    numbersDoc?.slack?.numberOfNewSent.allPeriods || 0
   );
   const [numberOfReplies, setNumberOfReplies] = useState(
-    numbersDoc.slack?.numberOfReplies.allPeriods || 0
+    numbersDoc?.slack?.numberOfReplies.allPeriods || 0
   );
   useEffect(() => {
     // Since this is an unnamed asynchronous function, it is enclosed in parentheses for immediate execution upon declaration

--- a/components/common/Login.tsx
+++ b/components/common/Login.tsx
@@ -21,7 +21,10 @@ import GoogleCalendarIcon from '../../public/google-calendar-svgrepo-com.svg';
 import GitHubIcon2 from '../../public/github-svgrepo-com.svg';
 
 // Next related and Custom services
-import { createUserDoc } from '../../services/setDocToFirestore';
+import {
+  createNumbersDoc,
+  createUserDoc
+} from '../../services/setDocToFirestore';
 import Head from 'next/head';
 
 // Scopes in detail: https://developers.google.com/identity/protocols/oauth2/scopes#calendar
@@ -36,6 +39,7 @@ const Login = () => {
         // This gives you a Google Access Token. You can use it to access the Google API.
         const user = result.user;
         createUserDoc(user.uid);
+        createNumbersDoc(user.uid);
       })
       .then(() => {
         window.location.reload();
@@ -63,6 +67,7 @@ const Login = () => {
       .then((result) => {
         const user = result.user;
         createUserDoc(user.uid);
+        createNumbersDoc(user.uid);
       })
       .then(() => {
         window.location.reload();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,7 +103,7 @@ export const getServerSideProps: GetServerSideProps = async (
     // the user is authenticated!
     const { uid } = token;
     const userDoc = await getAUserDoc(uid);
-    const numbersDoc = await getANumbersDoc(uid);
+    const numbersDoc = (await getANumbersDoc(uid)) || {};
 
     // Profile list to be displayed on the left side
     const profileList = {
@@ -147,8 +147,9 @@ export const getServerSideProps: GetServerSideProps = async (
       : null;
 
     // Parameters for slack
-    const slackMemberId: string | undefined =
-      userDoc?.slack?.workspace?.[0]?.memberId;
+    const slackMemberId = userDoc?.slack?.workspace?.[0]?.memberId
+      ? userDoc.slack.workspace[0].memberId
+      : null;
     const slackAccessToken = `Bearer ${userDoc?.slack?.workspace?.[0]?.accessToken}`;
 
     // Pass data to the page via props

--- a/services/setDocToFirestore.tsx
+++ b/services/setDocToFirestore.tsx
@@ -10,6 +10,14 @@ const createUserDoc = async (docId: string) => {
   return;
 };
 
+const createNumbersDoc = async (docId: string) => {
+  const docRef = doc(db, 'numbers', docId);
+  const docData: NumbersType = {};
+  const option = { merge: true };
+  await setDoc(docRef, docData, option);
+  return;
+};
+
 const handleSubmitBasicInfo = async (
   event: React.FormEvent<HTMLFormElement>,
   docId: string
@@ -324,6 +332,7 @@ const UpdInsSlackNumbers = async ({
 };
 
 export {
+  createNumbersDoc,
   createUserDoc,
   handleSubmitBasicInfo,
   handleSubmitGithubAccessToken,


### PR DESCRIPTION
## Problem

If you have a new table, during development, you inevitably create a record in that table with the ID of the logged-in user. Then I forgot to take care of the new user, which would originally require creating a new table or record for a new user. As a result, the following error occurred.

![image](https://user-images.githubusercontent.com/4620828/177042269-1e392e20-f014-43c1-9af0-926f4c45744f.png)

## Solution

The above error was addressed. Specifically, the Numbers table is now created when a user logs in.

## Evidence

For mobile screens;

For desktop screens;

|Before (For a new user)|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177042269-1e392e20-f014-43c1-9af0-926f4c45744f.png)|

|After (For a new user)|
|---|
|![image](https://user-images.githubusercontent.com/4620828/177042326-8f30b744-cab7-48f8-9aca-98bc6bb0195f.png)|

### Environment Variables Setting

Do you require registration for the following console screens beside the source code? If so, please attach evidence of registration to each of the console screens below.

- GitHub Actions: No
- Vercel Hosting: No
- Firebase Console: No
- Google Cloud Platform: No
- Asana Developer Console: No
- Slack Developer Console: No

## Performance

No

## Caveats

No

## References

No
