### PR TITLE
Changed a link from "homepage" to "dashboard" in "home" button in sidebar

### DIFF
--- a/components/common/Sidebar.tsx
+++ b/components/common/Sidebar.tsx
@@ -20,7 +20,7 @@ const Sidebar = ({ handleClick }: SidebarProps) => {
         />
       </div>
       <nav>
-        <Link href='/'>
+        <Link href='/dashboard'>
           <a className='block py-2 px-4 rounded hover:bg-gray-700 hover:text-white'>
             Home
           </a>
@@ -93,11 +93,6 @@ const Sidebar = ({ handleClick }: SidebarProps) => {
         >
           Contact Us
         </a>
-        {/* <Link href="/company">
-          <a className="block py-2 px-4 rounded hover:bg-gray-700 hover:text-white">
-            Company
-          </a>
-        </Link> */}
       </nav>
     </div>
   );


### PR DESCRIPTION
## Problem

The home button on the sidebar led to the home page. This is because the link is a "/", but this URL was changed from the dashboard to the home page.

## Solution

Changed the link to the home button in the sidebar from "/" to "/dashboard".

## Evidence

No

### Environment Variables Setting

No

## Performance

No

## Help Pages

No

## Caveats

No

## References

No
