### PR TITLE
Fixed that Twitter card is unable to show its image

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,8 @@ function MyApp({ Component, pageProps }: AppProps) {
     'WorkStats is a dashboard tool for engineers and project managers engaged in system development to visualize their productivity and contributions in numbers. It aggregates various numbers from the platforms used by members and teams, such as GitHub for source control, Asana for task management, and Slack for communication tools.';
   const contentShort =
     'is a dashboard tool for engineers and PMs to quantify their productivity, aggregating various numbers from GitHub, Asana, Slack, etc.';
+  const imageURL =
+    'https://drive.google.com/uc?export=download&id=1oP-avBzGd6YCISYUia0XvklWuV3mOg3a';
 
   return (
     <>
@@ -21,10 +23,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <meta property='og:description' content={contentShort} />
         <meta property='og:type' content='website' />
         <meta property='og:url' content='https://workstats.dev' />
-        <meta
-          property='og:image'
-          content='https://drive.google.com/file/d/1oP-avBzGd6YCISYUia0XvklWuV3mOg3a/view?usp=sharing'
-        />
+        <meta property='og:image' content={imageURL} />
         <meta property='og:image:alt' content='WorkStats' />
         <meta property='og:image:type' content='image/png' />
         <meta property='og:site_name' content='WorkStats' />
@@ -33,10 +32,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <meta name='twitter:title' content='WorkStats' />
         <meta name='twitter:site' content='@workstatsdev' />
         <meta name='twitter:creator' content='@workstatsdev' />
-        <meta
-          name='twitter:image'
-          content='https://drive.google.com/file/d/1oP-avBzGd6YCISYUia0XvklWuV3mOg3a/view?usp=sharing'
-        />
+        <meta name='twitter:image' content={imageURL} />
         <meta name='viewport' content='width=device-width, initial-scale=1' />
         <link rel='icon' href='/icononly_transparent_nobuffer.ico' />
       </Head>


### PR DESCRIPTION
## Problem

There has been a bug ever since it was implemented that prevented Twitter card images from being displayed, but the cause of this bug has not been found until now.

https://betterprogramming.pub/add-a-twitter-card-to-your-website-69f7d53b68a8
This site shows that the Google Drive link is possible, but apparently the URL had to be converted. I did not know that. I don't know if this will solve the problem, but I'll give it a try.

## Solution

https://syncwithtech.blogspot.com/p/direct-download-link-generator.html
I replaced it with the converted URL as the site says.

## Evidence

It did not work in the official simulator provided by Twitter, but it worked in real Twitter. We use this as evidence.

![image](https://user-images.githubusercontent.com/4620828/182325267-6c07bf6e-7ea5-4f2e-ac5f-eb9646043ffd.png)

![image](https://user-images.githubusercontent.com/4620828/182324732-7e38b6d0-f687-40fb-ada1-377c79066de2.png)

### Environment Variables Setting

No

## Performance

No

## Help Pages

No

## Caveats

No

## References

No
