### PR TITLE
Temporary workaround for 500 error due to Firebase token expiring in 1 hour.

### DIFF
--- a/auth.tsx
+++ b/auth.tsx
@@ -23,7 +23,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         setLoading(false);
         return;
       } else {
-        const token = await user.getIdToken();
+        const token = await user.getIdToken(true); // forceRefresh = true
         nookies.set(undefined, 'token', token, {});
         setCurrentUser(user);
         setLoading(false);

--- a/pages/cancel-membership.tsx
+++ b/pages/cancel-membership.tsx
@@ -139,12 +139,16 @@ export const getServerSideProps: GetServerSideProps = async (
 ) => {
   const cookies = nookies.get(ctx);
   if (cookies.token) {
-    const token = await verifyIdToken(cookies.token);
-    const { uid } = token;
-    const userDoc = (await getAUserDoc(uid)) ? await getAUserDoc(uid) : null;
-    return {
-      props: { uid, userDoc }
-    };
+    try {
+      const token = await verifyIdToken(cookies.token);
+      const { uid } = token;
+      const userDoc = (await getAUserDoc(uid)) ? await getAUserDoc(uid) : null;
+      return {
+        props: { uid, userDoc }
+      };
+    } catch (error) {
+      return { props: {} };
+    }
   } else {
     return { props: {} as never };
   }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -103,92 +103,104 @@ Dashboard.requiresAuth = true;
 export const getServerSideProps: GetServerSideProps = async (
   ctx: GetServerSidePropsContext
 ) => {
+  // interface Cookies {
+  //   _ga: string;
+  //   token: string; // Firebase ID token. It starts with "eyJhbGciOiJS..."
+  //   _ga_45J7T193WF: string;
+  // }
   const cookies = nookies.get(ctx);
 
   if (cookies.token) {
-    const token = await verifyIdToken(cookies.token);
+    try {
+      const token = await verifyIdToken(cookies.token);
 
-    // the user is authenticated!
-    const { uid } = token;
-    const userDoc = await getAUserDoc(uid);
-    const numbersDoc = (await getANumbersDoc(uid)) || {};
+      // the user is authenticated!
+      const { uid } = token;
+      const userDoc = await getAUserDoc(uid);
+      const numbersDoc = (await getANumbersDoc(uid)) || {};
 
-    // Profile list to be displayed on the left side
-    const profileList = {
-      firstName: userDoc?.firstName ? userDoc.firstName : '',
-      middleName: userDoc?.middleName ? userDoc.middleName : '',
-      lastName: userDoc?.lastName ? userDoc.lastName : '',
-      department: userDoc?.department ? userDoc.department : '',
-      rank: userDoc?.rank ? userDoc.rank : '',
-      supervisor: userDoc?.supervisor ? userDoc.supervisor : '',
-      assessor: userDoc?.assessor ? userDoc.assessor : '',
-      assignedPj: userDoc?.assignedPj ? userDoc.assignedPj : '',
-      role: userDoc?.role ? userDoc.role : '',
-      avatarUrl: userDoc?.avatarUrl ? userDoc.avatarUrl : ''
-    };
+      // Profile list to be displayed on the left side
+      const profileList = {
+        firstName: userDoc?.firstName ? userDoc.firstName : '',
+        middleName: userDoc?.middleName ? userDoc.middleName : '',
+        lastName: userDoc?.lastName ? userDoc.lastName : '',
+        department: userDoc?.department ? userDoc.department : '',
+        rank: userDoc?.rank ? userDoc.rank : '',
+        supervisor: userDoc?.supervisor ? userDoc.supervisor : '',
+        assessor: userDoc?.assessor ? userDoc.assessor : '',
+        assignedPj: userDoc?.assignedPj ? userDoc.assignedPj : '',
+        role: userDoc?.role ? userDoc.role : '',
+        avatarUrl: userDoc?.avatarUrl ? userDoc.avatarUrl : ''
+      };
 
-    // Parameters for Asana
-    const asanaOAuthAccessToken = userDoc?.asana?.accessToken
-      ? userDoc.asana.accessToken
-      : null;
-    const asanaRefreshToken = userDoc?.asana?.refreshToken
-      ? userDoc.asana.refreshToken
-      : null;
-    const asanaUserId = userDoc?.asana?.userId ? userDoc.asana.userId : null;
-    const asanaWorkspaceId = userDoc?.asana?.workspace?.[0]?.workspaceId
-      ? userDoc.asana.workspace[0].workspaceId
-      : null;
+      // Parameters for Asana
+      const asanaOAuthAccessToken = userDoc?.asana?.accessToken
+        ? userDoc.asana.accessToken
+        : null;
+      const asanaRefreshToken = userDoc?.asana?.refreshToken
+        ? userDoc.asana.refreshToken
+        : null;
+      const asanaUserId = userDoc?.asana?.userId ? userDoc.asana.userId : null;
+      const asanaWorkspaceId = userDoc?.asana?.workspace?.[0]?.workspaceId
+        ? userDoc.asana.workspace[0].workspaceId
+        : null;
 
-    // Parameters for GitHub
-    const githubRepoName = userDoc?.github?.repositories?.[0]?.repo
-      ? userDoc.github.repositories[0].repo
-      : null;
-    const githubOwnerName = userDoc?.github?.repositories?.[0]?.owner
-      ? userDoc.github.repositories[0].owner
-      : null;
-    const githubUserId = userDoc?.github?.userId ? userDoc.github.userId : null;
-    const githubUserName = userDoc?.github?.userName
-      ? userDoc.github.userName
-      : null;
-    const githubAccessToken = userDoc?.github?.accessToken
-      ? userDoc.github.accessToken
-      : null;
+      // Parameters for GitHub
+      const githubRepoName = userDoc?.github?.repositories?.[0]?.repo
+        ? userDoc.github.repositories[0].repo
+        : null;
+      const githubOwnerName = userDoc?.github?.repositories?.[0]?.owner
+        ? userDoc.github.repositories[0].owner
+        : null;
+      const githubUserId = userDoc?.github?.userId
+        ? userDoc.github.userId
+        : null;
+      const githubUserName = userDoc?.github?.userName
+        ? userDoc.github.userName
+        : null;
+      const githubAccessToken = userDoc?.github?.accessToken
+        ? userDoc.github.accessToken
+        : null;
 
-    // Parameters for Slack
-    const slackMemberId = userDoc?.slack?.workspace?.[0]?.memberId
-      ? userDoc.slack.workspace[0].memberId
-      : null;
-    const slackAccessToken = `Bearer ${userDoc?.slack?.workspace?.[0]?.accessToken}`;
+      // Parameters for Slack
+      const slackMemberId = userDoc?.slack?.workspace?.[0]?.memberId
+        ? userDoc.slack.workspace[0].memberId
+        : null;
+      const slackAccessToken = `Bearer ${userDoc?.slack?.workspace?.[0]?.accessToken}`;
 
-    // Parameters for Google Calendar
-    const googleAccessToken = userDoc?.google?.workspace?.[0]?.accessToken
-      ? userDoc.google.workspace[0].accessToken
-      : null;
-    const googleRefreshToken = userDoc?.google?.workspace?.[0]?.refreshToken
-      ? userDoc.google.workspace[0].refreshToken
-      : null;
+      // Parameters for Google Calendar
+      const googleAccessToken = userDoc?.google?.workspace?.[0]?.accessToken
+        ? userDoc.google.workspace[0].accessToken
+        : null;
+      const googleRefreshToken = userDoc?.google?.workspace?.[0]?.refreshToken
+        ? userDoc.google.workspace[0].refreshToken
+        : null;
 
-    // Pass data to the page via props
-    return {
-      props: {
-        asanaUserId,
-        asanaWorkspaceId,
-        asanaOAuthAccessToken,
-        asanaRefreshToken,
-        githubRepoName,
-        githubOwnerName,
-        githubUserId,
-        githubUserName,
-        githubAccessToken,
-        googleAccessToken,
-        googleRefreshToken,
-        numbersDoc,
-        profileList,
-        slackAccessToken,
-        slackMemberId,
-        uid
-      }
-    };
+      // Pass data to the page via props
+      return {
+        props: {
+          asanaUserId,
+          asanaWorkspaceId,
+          asanaOAuthAccessToken,
+          asanaRefreshToken,
+          githubRepoName,
+          githubOwnerName,
+          githubUserId,
+          githubUserName,
+          githubAccessToken,
+          googleAccessToken,
+          googleRefreshToken,
+          numbersDoc,
+          profileList,
+          slackAccessToken,
+          slackMemberId,
+          uid
+        }
+      };
+    } catch (err) {
+      console.error(err);
+      return { props: {} };
+    }
   } else {
     return { props: {} as never };
   }

--- a/pages/user-settings.tsx
+++ b/pages/user-settings.tsx
@@ -777,38 +777,42 @@ export const getServerSideProps: GetServerSideProps = async (
 ) => {
   const cookies = nookies.get(ctx);
   if (cookies.token) {
-    const token = await verifyIdToken(cookies.token);
-    const { uid } = token;
-    const userDoc = (await getAUserDoc(uid)) ? await getAUserDoc(uid) : null;
-    const isGithubAuthenticated =
-      userDoc?.github?.accessToken && userDoc?.github?.accessToken !== ''
-        ? true
-        : false;
-    const isAsanaAuthenticated =
-      userDoc?.asana?.accessToken && userDoc?.asana?.accessToken !== ''
-        ? true
-        : false;
-    const isSlackAuthenticated =
-      userDoc?.slack?.workspace?.[0]?.accessToken &&
-      userDoc?.slack?.workspace?.[0]?.accessToken !== ''
-        ? true
-        : false;
-    const isGoogleAuthenticated =
-      userDoc?.google?.workspace?.[0]?.accessToken &&
-      userDoc?.google?.workspace?.[0]?.accessToken !== ''
-        ? true
-        : false;
+    try {
+      const token = await verifyIdToken(cookies.token);
+      const { uid } = token;
+      const userDoc = (await getAUserDoc(uid)) ? await getAUserDoc(uid) : null;
+      const isGithubAuthenticated =
+        userDoc?.github?.accessToken && userDoc?.github?.accessToken !== ''
+          ? true
+          : false;
+      const isAsanaAuthenticated =
+        userDoc?.asana?.accessToken && userDoc?.asana?.accessToken !== ''
+          ? true
+          : false;
+      const isSlackAuthenticated =
+        userDoc?.slack?.workspace?.[0]?.accessToken &&
+        userDoc?.slack?.workspace?.[0]?.accessToken !== ''
+          ? true
+          : false;
+      const isGoogleAuthenticated =
+        userDoc?.google?.workspace?.[0]?.accessToken &&
+        userDoc?.google?.workspace?.[0]?.accessToken !== ''
+          ? true
+          : false;
 
-    return {
-      props: {
-        uid,
-        userDoc,
-        isAsanaAuthenticated,
-        isGithubAuthenticated,
-        isGoogleAuthenticated,
-        isSlackAuthenticated
-      }
-    };
+      return {
+        props: {
+          uid,
+          userDoc,
+          isAsanaAuthenticated,
+          isGithubAuthenticated,
+          isGoogleAuthenticated,
+          isSlackAuthenticated
+        }
+      };
+    } catch (e) {
+      return { props: {} };
+    }
   } else {
     return { props: {} as never };
   }


### PR DESCRIPTION
## Problem

The old problem came back with the creation of the homepage: you know that Firebase's authentication expires after an hour, and because of that, you get a 500 error (Internal Server Error) after an hour if you access the site directly from your browser's favorites. At this time, reloading will fix the problem.

Other than that, a new bug has been created. The newly created home page (<Component /> to be precise) is not wrapped in auth.tsx (<AuthProvider> to be precise) and can be entered without being logged in.

So, while this page is open, the mechanism in auth.tsx to force re-authentication once every 10 minutes does not work. As a result, even in this case, I get a 500 error after an hour. And reloading does not fix it. This is quite a problem.

## Solution

The error location is here. Once the try-catch syntax has been changed to not drop even in the case of an error. The user will not see anything and will have to reload.

In fact, it should reload automatically or display the login component, but this is a temporary fix.

![image](https://user-images.githubusercontent.com/4620828/182418756-273df57d-a850-40fe-b4e3-f0c4bf801f01.png)

## Evidence

Forgot to take a screenshot. I opened the home page, closed the dashboard, waited an hour, opened the dashboard, and reproduced the problem.

After the fix, nothing is displayed, but I confirmed that I can get out of the 500 error loop.

![image](https://user-images.githubusercontent.com/4620828/182419321-32fa57ef-6180-444d-a2ec-cb3f7a3976ad.png)

### Environment Variables Setting

No

## Performance

No

## Help Pages

No

## Caveats

No

## References

No
