### PR TITLE
After touring on the dashboard, open the user settings page

### DIFF
--- a/components/onboarding/product-tour.tsx
+++ b/components/onboarding/product-tour.tsx
@@ -63,12 +63,18 @@ const Onboarding = ({
         newNumberOfTimesCompleted
       );
     }
+
+    // Go to the user settings page in another tab, which is the next thing to do
+    if (window.location.pathname === '/dashboard')
+      // eslint-disable-next-line quotes
+      confirm("Let's set it up right away!") &&
+        window.open('/user-settings', '_blank');
   };
   const onBeforeExit = (stepIndex: number) => {
     // For some reason, onExit is called when index = 0, and because of that, for some reason, step 1 is displayed twice, so prevent it. Instead, users cannot leave by pressing the escape button or off-screen during the first pop-up
     // Also added undefined. Couldn't figure out why, but it makes the behavior more stable.
     if (stepIndex === undefined || stepIndex === 0) return false;
-    return true;
+    return;
   };
   // For testing purposes
   // const onAfterChange = (newStepIndex: number) => {


### PR DESCRIPTION
## Issue

1. Tour on the dashboard screen does not transition to the user settings page after completion of the tour
2. As a result, I'm guessing, there are likely to be cases where users leave the site without knowing what to do next

## Solution

1. After touring the dashboard, open the user settings page forcefully

## Evidence

### Checklist

- [x] On the dashboard screen, when a tour is completed, the user is asked if he/she wants to go to the user settings page.
- [x] On the dashboard screen, if you finish the tour in the middle of the tour, you will be asked if you want to go to the user settings page.
- [x] If the user accepts the confirmation dialog, the User Preferences page opens in a separate tab and the user is redirected to the User Preferences page.
- [x] If the confirmation dialog is cancelled, the new page will not open.
- [x] No new page will be opened in the user settings page, even if you complete the tour or finish it in the middle of the tour.

### For desktop screens;

https://www.loom.com/share/0929251a66164af0b2568ab66c53df47
