### PR TITLE
Enabled hashtags on user settings page and pulsed linkage button when API not linked.

### DIFF
--- a/components/buttons/RequestGoogleOAuthButton.tsx
+++ b/components/buttons/RequestGoogleOAuthButton.tsx
@@ -10,7 +10,7 @@ interface PropTypes {
 const RequestGoogleOAuthButton = ({ label, handleClick }: PropTypes) => {
   return (
     <button
-      className='w-auto h-8 flex bg-white ring-1 ring-gray-300 hover:ring-gray-500 ml-3 mt-1 md:mt-0 pr-3 rounded place-items-center'
+      className='animate-pulse w-auto h-8 flex bg-white ring-1 ring-gray-300 hover:ring-gray-500 ml-3 mt-1 md:mt-0 pr-3 rounded place-items-center'
       onClick={handleClick}
     >
       <Image

--- a/components/buttons/RequestOAuthButton.tsx
+++ b/components/buttons/RequestOAuthButton.tsx
@@ -8,7 +8,7 @@ interface PropTypes {
 const RequestOAuthButton = ({ label, handleClick }: PropTypes) => {
   return (
     <button
-      className='w-auto h-8 md:h-8 bg-green-600 hover:bg-green-700 text-white font-semibold px-3 ml-3 mt-1 md:mt-0 rounded-lg inline-block align-middle'
+      className='animate-pulse w-auto h-8 md:h-8 bg-green-600 hover:bg-green-700 text-white font-semibold px-3 ml-3 mt-1 md:mt-0 rounded-lg inline-block align-middle'
       onClick={handleClick}
     >
       {label}

--- a/components/cards/CardListForAsana.tsx
+++ b/components/cards/CardListForAsana.tsx
@@ -120,7 +120,7 @@ const CardListForAsana = ({
         <GearIconLink
           mt={5}
           mb={2}
-          href='/user-settings'
+          href='/user-settings#asana'
           alt='Gear icon links to user settings'
         />
       </div>

--- a/components/cards/CardListForGithub.tsx
+++ b/components/cards/CardListForGithub.tsx
@@ -154,7 +154,7 @@ const CardListForGithub = ({
         <GearIconLink
           mt={5}
           mb={2}
-          href='/user-settings'
+          href='/user-settings#github'
           alt='Gear icon links to user settings'
           id='gear-icon'
         />

--- a/components/cards/CardListForGoogleCalendar.tsx
+++ b/components/cards/CardListForGoogleCalendar.tsx
@@ -83,7 +83,7 @@ const CardListForGoogleCalendar = ({
         <GearIconLink
           mt={5}
           mb={2}
-          href='/user-settings'
+          href='/user-settings#google'
           alt='Gear icon links to user settings'
         />
       </div>

--- a/components/cards/CardListForJira.tsx
+++ b/components/cards/CardListForJira.tsx
@@ -232,7 +232,7 @@ const CardListForJira = ({
         <GearIconLink
           mt={5}
           mb={2}
-          href='/user-settings' // #task-control-atlassian
+          href='/user-settings#jira'
           alt='Gear icon links to user settings'
         />
       </div>

--- a/components/cards/CardListForSlack.tsx
+++ b/components/cards/CardListForSlack.tsx
@@ -112,7 +112,7 @@ const CardListForSlack = ({
         <GearIconLink
           mt={5}
           mb={2}
-          href='/user-settings'
+          href='/user-settings#slack'
           alt='Gear icon links to user settings'
         />
       </div>

--- a/pages/user-settings.tsx
+++ b/pages/user-settings.tsx
@@ -64,6 +64,15 @@ const useUserSettings = () => {
     }
   }, [uid, isGithubAuthenticated]);
 
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash) {
+      setTimeout(() => {
+        document.querySelector(hash)?.scrollIntoView({ behavior: 'smooth' });
+      }, 100);
+    }
+  });
+
   return (
     <div className='px-4 md:px-5'>
       <Head>


### PR DESCRIPTION
## Issue

1. The gear icon on the dashboard screen allows you to jump to the user settings page, but it takes you to the top of the page. This is assumed to reduce user attention and cause users to leave the site.
2. After moving to the user settings page, users are not sure what to do, and we assume that they are leaving the site, and do not intuitively know if they should press the API linkage button.

## Solution

1. Enabled hashtags on user-settings page
3. Pulsed linkage button when API not linked.

## Evidence

### For desktop screens;

https://www.loom.com/share/c0181606d2ea4cf395b76dd1ed2e8121

## References

- https://github.com/vercel/next.js/issues/11109