### PR TITLE
Added notes in user settings page

### DIFF
--- a/components/user-settings/SettingsForAsana.tsx
+++ b/components/user-settings/SettingsForAsana.tsx
@@ -146,6 +146,17 @@ const SettingsForAsana = ({
           />
         )}
       </div>
+      <p className='py-1 ml-3 pl-1'>
+        Follow the steps below to tally your numbers.
+      </p>
+      <ol className='py-1 ml-3 pl-1 list-decimal list-inside' role='list'>
+        <li key={1}>Press the &quot;Connect with Asana&quot; button.</li>
+        <li key={2}>
+          According to the dialog, login to Asana, check the scopes and
+          authenticate them.
+        </li>
+        <li key={3}>Register a workspace you want to aggregate below.</li>
+      </ol>
       <form
         name='task-ticket'
         onSubmit={(e) => handleSubmitTaskTicket(e, uid)}
@@ -153,7 +164,6 @@ const SettingsForAsana = ({
         target='_self'
         autoComplete='off'
       >
-        <div className='h-3 md:h-3'></div>
         <div className='flex flex-wrap items-center'>
           <div className='md:ml-6 md:w-28'></div>
           <InputBox
@@ -234,6 +244,11 @@ const SettingsForAsana = ({
           <SubmitButton />
         </div>
       </form>
+      <p className='py-1 ml-3 pl-1'>
+        Press &quot;Disconnect with Asana&quot; to disconnect at any time. If
+        you have any concerns or requests, please feel free to ask us through
+        the &quot;Contact Us&quot; link in the side menu.
+      </p>
     </div>
   );
 };

--- a/components/user-settings/SettingsForAtlassian.tsx
+++ b/components/user-settings/SettingsForAtlassian.tsx
@@ -168,7 +168,16 @@ const SettingsForAtlassian = ({
           />
         )}
       </div>
-      <div className='h-3 md:h-3'></div>
+      <p className='py-1 ml-3 pl-1'>
+        Follow the steps below to tally your numbers.
+      </p>
+      <ol className='py-1 ml-3 pl-1 list-decimal list-inside' role='list'>
+        <li key={1}>Press the &quot;Connect with Atlassian&quot; button.</li>
+        <li key={2}>
+          According to the dialog, login to Atlassian, check the scopes and
+          authenticate them.
+        </li>
+      </ol>
       <div className='flex flex-wrap items-center'>
         <div className='md:ml-6 md:w-32'></div>
         <InputBox
@@ -245,6 +254,11 @@ const SettingsForAtlassian = ({
         />
         <div className='ml-2 md:ml-1 pl-1 md:pl-3'></div>
       </div>
+      <p className='py-1 ml-3 pl-1'>
+        Press &quot;Disconnect with Atlassian&quot; to disconnect at any time.
+        If you have any concerns or requests, please feel free to ask us through
+        the &quot;Contact Us&quot; link in the side menu.
+      </p>
     </div>
   );
 };

--- a/components/user-settings/SettingsForGitHub.tsx
+++ b/components/user-settings/SettingsForGitHub.tsx
@@ -142,12 +142,21 @@ const SettingsForGitHub = ({
           />
         )}
       </div>
-      <p className='py-1 ml-3 pl-1'>Follow the steps below to register.</p>
+      <p className='py-1 ml-3 pl-1'>
+        Follow the steps below to tally your numbers.
+      </p>
       <ol className='py-1 ml-3 pl-1 list-decimal list-inside' role='list'>
         <li key={1}>Press the &quot;Connect with GitHub&quot; button.</li>
         <li key={2}>
           According to the dialog, login to GitHub, check the scopes and
           authenticate them.
+          <ul className='ml-3 pl-1 list-disc list-inside' role='list'>
+            <li key={3}>
+              Due to scopes that GitHub provides, we request to read/write
+              access to the repository, but never actually write anything.
+            </li>
+            <li>We also never read the code itself.</li>
+          </ul>
         </li>
         <li key={3}>Register a repository you want to aggregate below.</li>
       </ol>

--- a/components/user-settings/SettingsForGoogle.tsx
+++ b/components/user-settings/SettingsForGoogle.tsx
@@ -112,6 +112,22 @@ const SettingsForGoogle = ({
           />
         )}
       </div>
+      <p className='py-1 ml-3 pl-1'>
+        Follow the steps below to tally your numbers.
+      </p>
+      <ol className='py-1 ml-3 pl-1 list-decimal list-inside' role='list'>
+        <li key={1}>Press the &quot;Connect with Google&quot; button.</li>
+        <li key={2}>
+          According to the dialog, login to Google, check the scopes and
+          authenticate them.
+        </li>
+        <li key={3}>
+          You may have logged into this WorkStats with Google in the first
+          place, but the login and aggregation are managed separately.
+          Therefore, it is possible to aggregate with a different Google account
+          than the one used for login.
+        </li>
+      </ol>
       <form
         name='communication-activity-google'
         // onSubmit={}
@@ -119,7 +135,6 @@ const SettingsForGoogle = ({
         target='_self'
         autoComplete='off'
       >
-        <div className='h-3 md:h-3'></div>
         <h3 className='md:hidden text-lg ml-2 pl-1 w-32 underline underline-offset-1'>
           Workspace 1 :
         </h3>
@@ -162,6 +177,11 @@ const SettingsForGoogle = ({
           </div>
         </div>
       </form>
+      <p className='py-1 ml-3 pl-1'>
+        Press &quot;Disconnect with Google&quot; to disconnect at any time. If
+        you have any concerns or requests, please feel free to ask us through
+        the &quot;Contact Us&quot; link in the side menu.
+      </p>
     </div>
   );
 };

--- a/components/user-settings/SettingsForSlack.tsx
+++ b/components/user-settings/SettingsForSlack.tsx
@@ -122,6 +122,16 @@ const SettingsForSlack = ({
           />
         )}
       </div>
+      <p className='py-1 ml-3 pl-1'>
+        Follow the steps below to tally your numbers.
+      </p>
+      <ol className='py-1 ml-3 pl-1 list-decimal list-inside' role='list'>
+        <li key={1}>Press the &quot;Connect with Slack&quot; button.</li>
+        <li key={2}>
+          According to the dialog, login to Slack workspace, check the scopes
+          and authenticate them.
+        </li>
+      </ol>
       <form
         name='communication-activity'
         onSubmit={(e) => handleSubmitCommunicationActivity(e, uid)}
@@ -129,7 +139,6 @@ const SettingsForSlack = ({
         target='_self'
         autoComplete='off'
       >
-        <div className='h-3 md:h-3'></div>
         <h3 className='md:hidden text-lg ml-2 pl-1 w-32 underline underline-offset-1'>
           Workspace 1 :
         </h3>
@@ -198,6 +207,11 @@ const SettingsForSlack = ({
           </div>
         </div>
       </form>
+      <p className='py-1 ml-3 pl-1'>
+        Press &quot;Disconnect with Slack&quot; to disconnect at any time. If
+        you have any concerns or requests, please feel free to ask us through
+        the &quot;Contact Us&quot; link in the side menu.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Issue

1. There was no explanation of API integration on the user settings page.
2. There was a help page, but users had to open a separate tab, which was a bit time-consuming.
3. As a result, we assume that users are not reassured, causing them to leave the site.

## Solution

1. Added explanations and notes for each API linkage.

## Evidence

### For desktop screens;

![image](https://user-images.githubusercontent.com/4620828/194690151-8beb4d65-f2d3-44cc-89c8-65882bdbd23c.png)
