### PR TITLE
Hotfix: Slack numbers in this week does not work on Sunday

### DIFF
--- a/components/cards/CardListForSlack.tsx
+++ b/components/cards/CardListForSlack.tsx
@@ -53,9 +53,14 @@ const CardListForSlack = ({
   // Set time period from global state
   const since =
     currentTimeframe?.timeframe.since?.format('YYYY-MM-DD') || '2000-01-01';
-  const until =
+  const preUntil =
     currentTimeframe?.timeframe.until?.format('YYYY-MM-DD') ||
     moment().format('YYYY-MM-DD');
+  // If it is Sunday, this week set a same date to since and until, then it does not work properly in Slack API due to its specification.
+  const until =
+    preUntil === since
+      ? moment(preUntil).add(1, 'days').format('YYYY-MM-DD')
+      : preUntil;
 
   // Aggregate numbers from slack
   const numberOfTotalSentCalc = useSlackSearch({


### PR DESCRIPTION
## Issue

1. This Week" does not work well on Sundays
2. On Sunday, "Since" and "Until" dates are the same, but I actually tried the same thing in Slack's desktop app and couldn't get a good search
3. Specifically, for Sunday, October 9, 2022, "Since" and "Until" should be October 9, respectively, but for some reason the search range changes to October 8 - October 10

![image](https://user-images.githubusercontent.com/4620828/194768742-5c3832ab-3d23-40d5-b2d5-8c7175ef390d.png)

## Solution

1. If "Since" and "Until" are the same date, add one day to the "Until" date.
2. This only occurs when using "This Week" on Sunday

## Evidence

Sunday ended while I was working on it, so I can no longer leave evidence, I'll use the Slack desktop app evidence as an alternative.

![image](https://user-images.githubusercontent.com/4620828/194768873-121135c0-e69a-4181-9948-bc071d524dea.png)
