### PR TITLE
Hotfix: Supported API rate limit for slack chart page

### DIFF
--- a/services/slackServices.client.ts
+++ b/services/slackServices.client.ts
@@ -144,6 +144,12 @@ const SearchSlackMessages = async ({
     body.page = body.page + 1;
     fetchOptions.body = JSON.stringify(body);
     hasMore = body.page <= json.messages.paging.pages;
+
+    // This search API can only be called up to 20 times per minute, so for every 20 calls, it waits one minute, which is 60000 milliseconds.
+    // https://api.slack.com/docs/rate-limits#tier_t2
+    if (hasMore && body.page > 20 && body.page % 20 === 1) {
+      await new Promise((resolve) => setTimeout(resolve, 60000));
+    }
   }
 
   // Append some data to the messages array


### PR DESCRIPTION
## Issue

1. Slack's search API call limit is 20 calls per minute
2. The maximum number of retrieval cases per API call is 100
3. So, for example, if a user replies more than 2,000 times, an error will occur.
4. In fact, in a production environment, an error occurred for a user

## Solution

1. When calling the API more than 20 times, added a process to wait 1 minute for every 20 calls.

### Reference

- [Rate Limits](https://api.slack.com/docs/rate-limits#tier_t2)
- [Remainder (%)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder)