### PR TITLE
Hotfix: Slack search will be unstable after 10,000 results, so we will assume 2 years for now.

### DIFF
--- a/pages/charts/slack.tsx
+++ b/pages/charts/slack.tsx
@@ -47,7 +47,7 @@ export default function SlackCharts() {
   const currentTimeframe = globalState.currentTimeframe;
 
   // Set time period from global state
-  const oldest = '2000-01-01';
+  const oldest = moment().subtract(2, 'years').format('YYYY-MM-DD'); // Since exceeding 10,000 cases would be unstable, the period is set at 2 years for now.
   const latest = moment().format('YYYY-MM-DD');
   const createdSince =
     currentTimeframe?.timeframe.since?.format('YYYY-MM-DD') || oldest;


### PR DESCRIPTION
## Issue

1. Slack search will be unstable after 10,000 results

## Solution

1. so we will assume 2 years for now.

![S__12648493](https://user-images.githubusercontent.com/4620828/198838217-b0db3377-761a-4dee-b34a-eefefd1cd4ea.jpg)
![S__12648494](https://user-images.githubusercontent.com/4620828/198838221-3157b528-78ff-4bf4-b2af-abe330e817dd.jpg)
![S__12681238](https://user-images.githubusercontent.com/4620828/198838227-840f8b74-0e31-42a3-b9ee-790ba16d277c.jpg)
![S__12681239](https://user-images.githubusercontent.com/4620828/198838229-f0aeddae-0326-4218-b970-c50afe64a55a.jpg)

![image](https://user-images.githubusercontent.com/4620828/198838248-82ee23d8-acda-4450-859b-65b35159a42f.png)
<img width="960" alt="2022-10-29 (4)" src="https://user-images.githubusercontent.com/4620828/198838268-c6cc7a38-ac8e-458b-b897-1a8edb6b48c6.png">
